### PR TITLE
Skip adding devise.rb if it already exists.

### DIFF
--- a/lib/generators/solidus/auth/install/install_generator.rb
+++ b/lib/generators/solidus/auth/install/install_generator.rb
@@ -9,8 +9,7 @@ module Solidus
         end
 
         def generate_devise_key
-          return if ENV['TRAVIS']
-          template 'config/initializers/devise.rb', 'config/initializers/devise.rb'
+          template 'config/initializers/devise.rb', 'config/initializers/devise.rb', skip: true
         end
 
         def add_migrations


### PR DESCRIPTION
Solves an issue with CI since Solidus also decides to add the same file resulting in a conflict. Additionally, if a user already has a devise.rb, it's probably better than the one we were going to generate for them anyway.
