### PR TITLE
Remove some redundant includes

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -1,7 +1,5 @@
 module Spree
   class User < ActiveRecord::Base
-    include UserAddress
-    include UserPaymentSource
     include UserMethods
 
     devise :database_authenticatable, :registerable, :recoverable,


### PR DESCRIPTION
UserMethods was added in 953d1ddffec1e7b7d3290e10c8abbf9f02c98a2c and
it already includes these two modules.

This happens to make it easier for us to do some address refactoring
as well.