### PR TITLE
Explicitely add deface to gemfile

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "solidus_core", solidus_version
   s.add_dependency "devise", '~> 3.5.1'
   s.add_dependency "devise-encryptable", "0.1.2"
+  s.add_dependency 'deface', '~> 1.0.0'
 
   s.add_dependency "json"
   s.add_dependency "multi_json"


### PR DESCRIPTION
Right now deface is pulled in as part of Solidus's dependencies, however
its *auth_devise* and not solidus that requires deface.

This would be an early step in my Evil Plan(tm) to remove deface.