### PR TITLE
Inherit from Spree::Base

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -1,5 +1,5 @@
 module Spree
-  class User < ActiveRecord::Base
+  class User < Spree::Base
     include UserMethods
 
     devise :database_authenticatable, :registerable, :recoverable,


### PR DESCRIPTION
As that's now the base class all models should inherit from to get things such as `ransackable_attributes`. Fixes #18.