### PR TITLE
Automatically regenerate a user's spree_api_key upon password change.

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -8,6 +8,7 @@ module Spree
 
     acts_as_paranoid
     after_destroy :scramble_email_and_password
+    before_update { generate_spree_api_key if encrypted_password_changed? && spree_api_key.present? }
 
     has_many :orders
 

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "solidus_auth_devise"
-  s.version     = "1.2.1"
+  s.version     = "1.2.2"
   s.summary     = "Provides authentication and authorization services for use with Solidus by using Devise and CanCan."
   s.description = s.summary
 
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  solidus_version = [">= 1.0.0.pre2", "< 2"]
+  solidus_version = [">= 1.1.0.alpha", "< 2"]
 
   s.add_dependency "solidus_core", solidus_version
   s.add_dependency "devise", '~> 3.5.1'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,11 +7,31 @@ RSpec.describe Spree::User, type: :model do
     expect(create(:user).admin?).to be false
   end
 
-  it 'generates the reset password token' do
-    user = create(:user)
-    expect(Spree::UserMailer).to receive(:reset_password_instructions).with(user, anything, {}).and_return(double(deliver: true))
-    user.send_reset_password_instructions
-    expect(user.reset_password_token).not_to be_nil
+  context "recoverable" do
+    let(:user) { create(:user) }
+
+    it 'generates the reset password token' do
+      expect(Spree::UserMailer).to receive(:reset_password_instructions).with(user, anything, {}).and_return(double(deliver: true))
+      expect { user.send_reset_password_instructions }.to change(user, :reset_password_token).to be_present
+    end
+
+    it "regenerates a spree api key on successful password change" do
+      user.generate_spree_api_key!
+
+      user.password = "123456678"
+      user.password_confirmation = "123456678"
+      expect { user.save! }.to change(user, :spree_api_key)
+      expect(user.spree_api_key).to be_present
+    end
+
+    it "does not generate a spree api key on password change if no key existed previously" do
+      user.clear_spree_api_key!
+
+      user.password = "123456678"
+      user.password_confirmation = "123456678"
+      expect { user.save! }.not_to change(user, :spree_api_key)
+      expect(user.reload.spree_api_key).to be_nil
+    end
   end
 
   context '#destroy' do


### PR DESCRIPTION
When a user changes their password, it seems wise to also regenerate
their api key as an added security measure.