### PR TITLE
Missing translations for German locale

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,5 +1,7 @@
 ---
 de:
+  spree:
+    admin_login: Admin anmelden
   devise:
     confirmations:
       confirmed: Ihr Konto wurde erfolgreich aktiviert.
@@ -38,6 +40,7 @@ de:
     user_sessions:
       signed_in: Erfolgreich angemeldet.
       signed_out: Erfolgreich abgemeldet.
+      already_signed_in: Bereits angemeldet.
   errors:
     messages:
       already_confirmed: wurde berreits bestätigt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   spree:
-    admin_login: "Admin Login"
+    admin_login: Admin Login
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.
@@ -21,8 +21,6 @@ en:
         subject: Reset password instructions
       unlock_instructions:
         subject: Unlock Instructions
-      confirmation_instructions:
-        subject: Confirmation instructions
     oauth_callbacks:
       failure: 'Could not authorize you from %{kind} because %{reason}.'
       success: 'Successfully authorized from %{kind} account.'


### PR DESCRIPTION
Fix a couple of missing translations for the German locale file and also remove a duplicate translation from the English locale.