### PR TITLE
Allow to create a new session via API without authenticity token

### DIFF
--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -1,4 +1,8 @@
 class Spree::UserSessionsController < Devise::SessionsController
+
+  # Allow to create a new session via API without authenticity token
+  protect_from_forgery with: :null_session
+
   helper 'spree/base', 'spree/store'
   if Spree::Auth::Engine.dash_available?
     helper 'spree/analytics'


### PR DESCRIPTION
When trying to create a new session via API, it raises a ActionController::InvalidAuthenticityToken exception.
A possible solution is discussed here: https://github.com/plataformatec/devise/issues/2432#issuecomment-18973236
and here: https://github.com/rails/rails/blob/e20dd73df42d63b206d221e2258cc6dc7b1e6068/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb.tt
