### PR TITLE
Re-add Solidus 1.0 compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ rvm:
   - 2.1.8
 env:
   matrix:
+    - SOLIDUS_BRANCH=v1.0 DB=postgres
     - SOLIDUS_BRANCH=v1.1 DB=postgres
     - SOLIDUS_BRANCH=v1.2 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
+    - SOLIDUS_BRANCH=v1.0 DB=mysql
     - SOLIDUS_BRANCH=v1.1 DB=mysql
     - SOLIDUS_BRANCH=v1.2 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  solidus_version = [">= 1.1.0.alpha", "< 2"]
+  solidus_version = [">= 1.0.6", "< 2"]
 
   s.add_dependency "solidus_core", solidus_version
   s.add_dependency "devise", '~> 3.5.1'


### PR DESCRIPTION
Solidus 1.0.6 was released with a small backport in order to allow this.