### PR TITLE
Bumps solidus_version to 1.2.2

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  solidus_version = [">= 1.0.6", "< 2"]
+  solidus_version = ["= 1.2.2", "< 2"]
 
   s.add_dependency "solidus_core", solidus_version
   s.add_dependency "devise", '~> 3.5.1'


### PR DESCRIPTION
This PR bumps solidus_auth_devise to be compatible with upgrading to solidus 1.2.2 inside your project's Gemfile. NOTE: Please consider that it may be more appropriate to add this commit to add to a new branch of solidus_auth_devise called:   v1.2