### PR TITLE
ChcktController checks auth and registration first

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,7 +1,7 @@
 require 'spree/core/validators/email'
 Spree::CheckoutController.class_eval do
-  before_filter :check_authorization
-  before_filter :check_registration, :except => [:registration, :update_registration]
+  prepend_before_filter :check_authorization
+  prepend_before_filter :check_registration, :except => [:registration, :update_registration]
 
   def registration
     @user = Spree::User.new


### PR DESCRIPTION
The CheckoutController's check_authorization and check_registration
filters should be prepended in the filter chain so that any subsequent
methods invoked in the filter chain which depend on the presence of a
valid user are not invoked if that user is not authorized or
registration is required.