### PR TITLE
check_authorization first in CheckoutController

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,7 +1,7 @@
 require 'spree/core/validators/email'
 Spree::CheckoutController.class_eval do
-  prepend_before_filter :check_authorization
   prepend_before_filter :check_registration, :except => [:registration, :update_registration]
+  prepend_before_filter :check_authorization # must be last prepend_before_filter
 
   def registration
     @user = Spree::User.new


### PR DESCRIPTION
When we changed this to a prepend_before_filter we failed to recognize
that we needed to change the sequence of the filter definitions so that
check_authorization would fire before check_registration.