### PR TITLE
Revert "ChcktController checks auth and registration first"

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,7 +1,7 @@
 require 'spree/core/validators/email'
 Spree::CheckoutController.class_eval do
-  prepend_before_filter :check_authorization
-  prepend_before_filter :check_registration, :except => [:registration, :update_registration]
+  before_filter :check_authorization
+  before_filter :check_registration, :except => [:registration, :update_registration]
 
   def registration
     @user = Spree::User.new


### PR DESCRIPTION
Reverts solidusio/solidus_auth_devise#44

This change introduces a regression caused by check_registration depending on check_authorization running first. The simple thing to do would be to flip the filter definitions, but I think it's better we fix the temporal coupling of these methods. I'll take a shot at that in a fresh PR. Until that's resolved, let's not make trouble for anyone else.