### PR TITLE
check_authorization first in CheckoutController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 .ruby-version
 .bundle
 pkg
+vendor

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -47,7 +47,8 @@ Spree::CheckoutController.class_eval do
     end
 
     def guest_authenticated?
-      current_order.email.present? && Spree::Config[:allow_guest_checkout]
+      current_order.try!(:email).present? &&
+        Spree::Config[:allow_guest_checkout]
     end
 
     # Overrides the equivalent method defined in Spree::Core.  This variation of the method will ensure that users

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,7 +1,8 @@
 require 'spree/core/validators/email'
 Spree::CheckoutController.class_eval do
-  before_filter :check_authorization
-  before_filter :check_registration, :except => [:registration, :update_registration]
+  prepend_before_filter :check_registration,
+    except: [:registration, :update_registration]
+  prepend_before_filter :check_authorization
 
   def registration
     @user = Spree::User.new


### PR DESCRIPTION
When we changed this to a prepend_before_filter we failed to recognize
that we needed to change the sequence of the filter definitions so that
check_authorization would fire before check_registration.

Also:
* adds a guard to a call to `current_order` which may be `nil`
* Adds `vendor` to `.gitignore`