### PR TITLE
Conditional routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,20 +16,20 @@ Spree::Core::Engine.add_routes do
     resources :users, :only => [:edit, :update]
 
     devise_scope :spree_user do
-      get '/login' => 'user_sessions#new', :as => :login
-      post '/login' => 'user_sessions#create', :as => :create_new_session
-      get '/logout' => 'user_sessions#destroy', :as => :logout
-      get '/signup' => 'user_registrations#new', :as => :signup
-      post '/signup' => 'user_registrations#create', :as => :registration
-      get '/password/recover' => 'user_passwords#new', :as => :recover_password
-      post '/password/recover' => 'user_passwords#create', :as => :reset_password
-      get '/password/change' => 'user_passwords#edit', :as => :edit_password
-      put '/password/change' => 'user_passwords#update', :as => :update_password
-      get '/confirm' => 'user_confirmations#show', :as => :confirmation if Spree::Auth::Config[:confirmable]
+      get '/login', :to => 'user_sessions#new', :as => :login
+      post '/login', :to => 'user_sessions#create', :as => :create_new_session
+      get '/logout', :to => 'user_sessions#destroy', :as => :logout
+      get '/signup', :to => 'user_registrations#new', :as => :signup
+      post '/signup', :to => 'user_registrations#create', :as => :registration
+      get '/password/recover', :to => 'user_passwords#new', :as => :recover_password
+      post '/password/recover', :to => 'user_passwords#create', :as => :reset_password
+      get '/password/change', :to => 'user_passwords#edit', :as => :edit_password
+      put '/password/change', :to => 'user_passwords#update', :as => :update_password
+      get '/confirm', :to => 'user_confirmations#show', :as => :confirmation if Spree::Auth::Config[:confirmable]
     end
 
-    get '/checkout/registration' => 'checkout#registration', :as => :checkout_registration
-    put '/checkout/registration' => 'checkout#update_registration', :as => :update_checkout_registration
+    get '/checkout/registration', :to => 'checkout#registration', :as => :checkout_registration
+    put '/checkout/registration', :to => 'checkout#update_registration', :as => :update_checkout_registration
 
     resource :account, :controller => 'users'
   end
@@ -49,9 +49,9 @@ Spree::Core::Engine.add_routes do
 
       devise_scope :spree_user do
         get '/authorization_failure', :to => 'user_sessions#authorization_failure', :as => :unauthorized
-        get '/login' => 'user_sessions#new', :as => :login
-        post '/login' => 'user_sessions#create', :as => :create_new_session
-        get '/logout' => 'user_sessions#destroy', :as => :logout
+        get '/login', :to => 'user_sessions#new', :as => :login
+        post '/login', :to => 'user_sessions#create', :as => :create_new_session
+        get '/logout', :to => 'user_sessions#destroy', :as => :logout
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,25 +13,25 @@ Spree::Core::Engine.add_routes do
       path_prefix: :user
     })
 
-    resources :users, :only => [:edit, :update]
+    resources :users, only: [:edit, :update]
 
     devise_scope :spree_user do
-      get '/login', :to => 'user_sessions#new', :as => :login
-      post '/login', :to => 'user_sessions#create', :as => :create_new_session
-      get '/logout', :to => 'user_sessions#destroy', :as => :logout
-      get '/signup', :to => 'user_registrations#new', :as => :signup
-      post '/signup', :to => 'user_registrations#create', :as => :registration
-      get '/password/recover', :to => 'user_passwords#new', :as => :recover_password
-      post '/password/recover', :to => 'user_passwords#create', :as => :reset_password
-      get '/password/change', :to => 'user_passwords#edit', :as => :edit_password
-      put '/password/change', :to => 'user_passwords#update', :as => :update_password
-      get '/confirm', :to => 'user_confirmations#show', :as => :confirmation if Spree::Auth::Config[:confirmable]
+      get '/login', to: 'user_sessions#new', as: :login
+      post '/login', to: 'user_sessions#create', as: :create_new_session
+      get '/logout', to: 'user_sessions#destroy', as: :logout
+      get '/signup', to: 'user_registrations#new', as: :signup
+      post '/signup', to: 'user_registrations#create', as: :registration
+      get '/password/recover', to: 'user_passwords#new', as: :recover_password
+      post '/password/recover', to: 'user_passwords#create', as: :reset_password
+      get '/password/change', to: 'user_passwords#edit', as: :edit_password
+      put '/password/change', to: 'user_passwords#update', as: :update_password
+      get '/confirm', to: 'user_confirmations#show', as: :confirmation if Spree::Auth::Config[:confirmable]
     end
 
-    get '/checkout/registration', :to => 'checkout#registration', :as => :checkout_registration
-    put '/checkout/registration', :to => 'checkout#update_registration', :as => :update_checkout_registration
+    get '/checkout/registration', to: 'checkout#registration', as: :checkout_registration
+    put '/checkout/registration', to: 'checkout#update_registration', as: :update_checkout_registration
 
-    resource :account, :controller => 'users'
+    resource :account, controller: 'users'
   end
 
   if Spree::Auth::Engine.backend_available?
@@ -48,10 +48,10 @@ Spree::Core::Engine.add_routes do
       })
 
       devise_scope :spree_user do
-        get '/authorization_failure', :to => 'user_sessions#authorization_failure', :as => :unauthorized
-        get '/login', :to => 'user_sessions#new', :as => :login
-        post '/login', :to => 'user_sessions#create', :as => :create_new_session
-        get '/logout', :to => 'user_sessions#destroy', :as => :logout
+        get '/authorization_failure', to: 'user_sessions#authorization_failure', as: :unauthorized
+        get '/login', to: 'user_sessions#new', as: :login
+        post '/login', to: 'user_sessions#create', as: :create_new_session
+        get '/logout', to: 'user_sessions#destroy', as: :logout
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,48 +1,58 @@
 Spree::Core::Engine.add_routes do
-  devise_for :spree_user,
-             :class_name => 'Spree::User',
-             :controllers => { :sessions => 'spree/user_sessions',
-                               :registrations => 'spree/user_registrations',
-                               :passwords => 'spree/user_passwords',
-                               :confirmations => 'spree/user_confirmations' },
-             :skip => [:unlocks, :omniauth_callbacks],
-             :path_names => { :sign_out => 'logout' },
-             :path_prefix => :user
+  if Spree::Auth::Engine.frontend_available?
+    devise_for(:spree_user, {
+      class_name: 'Spree::User',
+      controllers: {
+        sessions: 'spree/user_sessions',
+        registrations: 'spree/user_registrations',
+        passwords: 'spree/user_passwords',
+        confirmations: 'spree/user_confirmations'
+      },
+      skip: [:unlocks, :omniauth_callbacks],
+      path_names: { sign_out: 'logout' },
+      path_prefix: :user
+    })
 
-  resources :users, :only => [:edit, :update]
+    resources :users, :only => [:edit, :update]
 
-  devise_scope :spree_user do
-    get '/login' => 'user_sessions#new', :as => :login
-    post '/login' => 'user_sessions#create', :as => :create_new_session
-    get '/logout' => 'user_sessions#destroy', :as => :logout
-    get '/signup' => 'user_registrations#new', :as => :signup
-    post '/signup' => 'user_registrations#create', :as => :registration
-    get '/password/recover' => 'user_passwords#new', :as => :recover_password
-    post '/password/recover' => 'user_passwords#create', :as => :reset_password
-    get '/password/change' => 'user_passwords#edit', :as => :edit_password
-    put '/password/change' => 'user_passwords#update', :as => :update_password
-    get '/confirm' => 'user_confirmations#show', :as => :confirmation if Spree::Auth::Config[:confirmable]
-  end
-
-  get '/checkout/registration' => 'checkout#registration', :as => :checkout_registration
-  put '/checkout/registration' => 'checkout#update_registration', :as => :update_checkout_registration
-
-  resource :account, :controller => 'users'
-
-  namespace :admin do
-    devise_for :spree_user,
-               :class_name => 'Spree::User',
-               :controllers => { :sessions => 'spree/admin/user_sessions',
-                                 :passwords => 'spree/admin/user_passwords' },
-               :skip => [:unlocks, :omniauth_callbacks, :registrations],
-               :path_names => { :sign_out => 'logout' },
-               :path_prefix => :user
     devise_scope :spree_user do
-      get '/authorization_failure', :to => 'user_sessions#authorization_failure', :as => :unauthorized
       get '/login' => 'user_sessions#new', :as => :login
       post '/login' => 'user_sessions#create', :as => :create_new_session
       get '/logout' => 'user_sessions#destroy', :as => :logout
+      get '/signup' => 'user_registrations#new', :as => :signup
+      post '/signup' => 'user_registrations#create', :as => :registration
+      get '/password/recover' => 'user_passwords#new', :as => :recover_password
+      post '/password/recover' => 'user_passwords#create', :as => :reset_password
+      get '/password/change' => 'user_passwords#edit', :as => :edit_password
+      put '/password/change' => 'user_passwords#update', :as => :update_password
+      get '/confirm' => 'user_confirmations#show', :as => :confirmation if Spree::Auth::Config[:confirmable]
     end
 
+    get '/checkout/registration' => 'checkout#registration', :as => :checkout_registration
+    put '/checkout/registration' => 'checkout#update_registration', :as => :update_checkout_registration
+
+    resource :account, :controller => 'users'
+  end
+
+  if Spree::Auth::Engine.backend_available?
+    namespace :admin do
+      devise_for(:spree_user, {
+        class_name: 'Spree::User',
+        controllers: {
+          sessions: 'spree/admin/user_sessions',
+          passwords: 'spree/admin/user_passwords'
+        },
+        skip: [:unlocks, :omniauth_callbacks, :registrations],
+        path_names: { sign_out: 'logout' },
+        path_prefix: :user
+      })
+
+      devise_scope :spree_user do
+        get '/authorization_failure', :to => 'user_sessions#authorization_failure', :as => :unauthorized
+        get '/login' => 'user_sessions#new', :as => :login
+        post '/login' => 'user_sessions#create', :as => :create_new_session
+        get '/logout' => 'user_sessions#destroy', :as => :logout
+      end
+    end
   end
 end


### PR DESCRIPTION
Steps have been taken to avoid loading certain code depending on the
presence of spree_frontend and spree_backend, but the routing was never
updated. This change conditionally loads devise routes based on the
presence of spree_frontend and spree_backend.

Also updates the syntax of routing file.