### PR TITLE
Call set_current_order explicitly where we need it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Solidus Auth Devise v1.5.0 (master, unreleased)
 
+* Add call to set_current_order on sign in. This replaces a before filter that is being eliminated from Solidus controllers where set_current_order was called excessively.
+
 ## Solidus Auth Devise v1.4.0 (2016-05-16)
 
 * Update hash syntax for routes.rb

--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -9,6 +9,10 @@ class Spree::UserSessionsController < Devise::SessionsController
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Store
 
+  # This is included in ControllerHelpers::Order.  We just want to call
+  # it after someone has successfully logged in.
+  after_action :set_current_order, only: :create
+
   def create
     authenticate_spree_user!
 


### PR DESCRIPTION
set_current_order will be moved out of a before_filter in the ControllerHelpers::Order module in solidus.  This is currently hitting the database on just about every frontend page load when we really just need it when someone is signing in.  This moves that call to signing in in solidus auth and should be applied in conjunction with https://github.com/solidusio/solidus/pull/1137.
