### PR TITLE
Backend views should only reference backend routes

### DIFF
--- a/lib/views/backend/spree/layouts/admin/_login_nav.html.erb
+++ b/lib/views/backend/spree/layouts/admin/_login_nav.html.erb
@@ -1,7 +1,7 @@
 <% if spree_current_user %>
   <ul id="login-nav" class="inline-menu">
     <li data-hook="user-logged-in-as"><%= Spree.t(:logged_in_as) %>: <%= spree_current_user.email %></li>
-    <li data-hook="user-account-link" class='fa fa-user'><%= link_to Spree.t(:account), spree.edit_user_path(spree_current_user) %></li>
+    <li data-hook="user-account-link" class='fa fa-user'><%= link_to Spree.t(:account), spree.edit_admin_user_path(spree_current_user) %></li>
     <li data-hook="user-logout-link" class='fa fa-sign-out'><%= link_to Spree.t(:logout), spree.admin_logout_path %></li>
 
     <% if spree.respond_to? :root_path %>


### PR DESCRIPTION
Some solidus_auth_devise users will not be using solidus_frontend and
therefore, may not have the non-admin version of the user route helpers.