### PR TITLE
Misc: Update Dependency Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,28 @@
 ## Solidus Auth Devise v1.5.0 (master, unreleased)
 
-* Add call to set_current_order on sign in. This replaces a before filter that is being eliminated from Solidus controllers where set_current_order was called excessively.
+* Add call to set_current_order on sign in. This replaces a before filter that
+  is being eliminated from Solidus controllers where set_current_order was
+  called excessively.
+
 * Update backend views to only reference backend routes (#57)
+
+* Devise dependency updates
+
+  The locked versions of Devise and Devise-Encryptable have been updated.
+  Devise, in particular, has been bumped to a new major version, which removes
+  support for the following:
+
+  - Rails 3.2. and 4.0
+  - Ruby 1.9 and 2.0
+
+  These losses are deemed acceptable, as Solidus' core itself does not
+  support any of these versions.
+
+  For more details on the changes, see the Devise changelog:
+  https://github.com/plataformatec/devise/blob/master/CHANGELOG.md
+
+  Similar changes in `devise-encryptable`, with details in the changelog:
+  https://github.com/plataformatec/devise-encryptable/blob/master/Changelog.md
 
 ## Solidus Auth Devise v1.4.0 (2016-05-16)
 

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -31,14 +31,14 @@ Gem::Specification.new do |s|
   s.add_development_dependency "solidus_backend", solidus_version
   s.add_development_dependency "solidus_frontend", solidus_version
   s.add_development_dependency "rspec-rails", "~> 3.3"
-  s.add_development_dependency "simplecov", "~> 0.9.0"
+  s.add_development_dependency "simplecov", "~> 0.11.2"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "coffee-rails"
-  s.add_development_dependency "shoulda-matchers", "~> 2.6.2"
+  s.add_development_dependency "shoulda-matchers", "~> 3.1.1"
   s.add_development_dependency "factory_girl", "~> 4.4"
-  s.add_development_dependency "capybara", "~> 2.4.1"
+  s.add_development_dependency "capybara", "~> 2.7.1"
   s.add_development_dependency "poltergeist", "~> 1.5"
-  s.add_development_dependency "database_cleaner", "~> 1.2.0"
+  s.add_development_dependency "database_cleaner", "~> 1.5.3"
   s.add_development_dependency "capybara-screenshot"
 end

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   solidus_version = [">= 1.0.6", "< 2"]
 
   s.add_dependency "solidus_core", solidus_version
-  s.add_dependency "devise", '~> 3.5.1'
-  s.add_dependency "devise-encryptable", "0.1.2"
+  s.add_dependency "devise", '~> 4.1.0'
+  s.add_dependency "devise-encryptable", "0.2.0"
   s.add_dependency 'deface', '~> 1.0.0'
 
   s.add_dependency "json"


### PR DESCRIPTION
Bumps dependency versions to make sure we're up-to-date on everything.

For more details on the bigger version bumps, see [this commit](https://github.com/solidusio/solidus_auth_devise/commit/0601d6f6c1d81cf649d99b063195e45a727ecd5d).