### PR TITLE
Add guard for frontend-based AuthenticationHelpers

### DIFF
--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -2,25 +2,30 @@ module Spree
   module AuthenticationHelpers
     def self.included(receiver)
       receiver.send :helper_method, :spree_current_user
-      receiver.send :helper_method, :spree_login_path
-      receiver.send :helper_method, :spree_signup_path
-      receiver.send :helper_method, :spree_logout_path
+
+      if Spree::Auth::Engine.frontend_available?
+        receiver.send :helper_method, :spree_login_path
+        receiver.send :helper_method, :spree_signup_path
+        receiver.send :helper_method, :spree_logout_path
+      end
     end
 
     def spree_current_user
       current_spree_user
     end
 
-    def spree_login_path
-      spree.login_path
-    end
+    if Spree::Auth::Engine.frontend_available?
+      def spree_login_path
+        spree.login_path
+      end
 
-    def spree_signup_path
-      spree.signup_path
-    end
+      def spree_signup_path
+        spree.signup_path
+      end
 
-    def spree_logout_path
-      spree.logout_path
+      def spree_logout_path
+        spree.logout_path
+      end
     end
   end
 end


### PR DESCRIPTION
These `Spree::AuthenticationHelpers` methods should only be available for
apps that have `solidus_frontend` available, as they are simply proxies
for route helpers provided by that gem.

Closes #59.