### PR TITLE
Loosen devise dependency to ~> 4.1

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   solidus_version = [">= 1.0.6", "< 2"]
 
   s.add_dependency "solidus_core", solidus_version
-  s.add_dependency "devise", '~> 4.1.0'
+  s.add_dependency "devise", '~> 4.1'
   s.add_dependency "devise-encryptable", "0.2.0"
   s.add_dependency 'deface', '~> 1.0.0'
 


### PR DESCRIPTION
We should be using SemVer here. devise 4.2 is out now and is required for rails 5.