### PR TITLE
Remove load-time manipulation of the secret_key

### DIFF
--- a/lib/spree/auth/devise.rb
+++ b/lib/spree/auth/devise.rb
@@ -3,18 +3,12 @@ require 'devise'
 require 'devise-encryptable'
 require 'cancan'
 
-Devise.secret_key = SecureRandom.hex(50)
-
 module Spree
   module Auth
-    mattr_accessor :default_secret_key
-
     def self.config(&block)
       yield(Spree::Auth::Config)
     end
   end
 end
-
-Spree::Auth.default_secret_key = Devise.secret_key
 
 require 'spree/auth/engine'

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -15,15 +15,6 @@ module Spree
         Spree.user_class = "Spree::User"
       end
 
-      initializer "solidus_auth_devise.check_secret_token" do
-        if Spree::Auth.default_secret_key == Devise.secret_key
-          puts "[WARNING] You are not setting Devise.secret_key within your application!"
-          puts "You must set this in config/initializers/devise.rb. Here's an example:"
-          puts " "
-          puts %Q{Devise.secret_key = "#{SecureRandom.hex(50)}"}
-        end
-      end
-
       config.to_prepare do
         auth = Spree::Auth::Engine
 


### PR DESCRIPTION
Devise knows best here. Let's let their errors and warnings cover the secret key.