### PR TITLE
Replace spree_{get,post,put,delete} with normal methods

### DIFF
--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe Spree::CheckoutController, type: :controller do
         before { allow(controller).to receive(:spree_current_user) { user } }
 
         it 'proceeds to the first checkout step' do
-          spree_get :edit, { state: 'address' }
+          get :edit, { state: 'address' }
           expect(response).to render_template :edit
         end
       end
 
       context 'when not authenticated as guest' do
         it 'redirects to registration step' do
-          spree_get :edit, { state: 'address' }
+          get :edit, { state: 'address' }
           expect(response).to redirect_to spree.checkout_registration_path
         end
       end
@@ -36,7 +36,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
         before { order.email = 'guest@solidus.io' }
 
         it 'proceeds to the first checkout step' do
-          spree_get :edit, { state: 'address' }
+          get :edit, { state: 'address' }
           expect(response).to render_template :edit
         end
 
@@ -50,7 +50,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
           end
 
           it 'redirects to registration step' do
-            spree_get :edit, { state: 'address' }
+            get :edit, { state: 'address' }
             expect(response).to redirect_to spree.checkout_registration_path
           end
         end
@@ -67,14 +67,14 @@ RSpec.describe Spree::CheckoutController, type: :controller do
         before { allow(controller).to receive(:spree_current_user) { user } }
 
         it 'proceeds to the first checkout step' do
-          spree_get :edit, { state: 'address' }
+          get :edit, { state: 'address' }
           expect(response).to render_template :edit
         end
       end
 
       context 'when authenticated as guest' do
         it 'proceeds to the first checkout step' do
-          spree_get :edit, { state: 'address' }
+          get :edit, { state: 'address' }
           expect(response).to render_template :edit
         end
       end
@@ -96,7 +96,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
 
         it 'redirects to the tokenized order view' do
           request.cookie_jar.signed[:guest_token] = 'ABC'
-          spree_post :update, { state: 'confirm' }
+          post :update, { state: 'confirm' }
           expect(response).to redirect_to spree.token_order_path(order, 'ABC')
           expect(flash.notice).to eq Spree.t(:order_processed_successfully)
         end
@@ -110,7 +110,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
         end
 
         it 'redirects to the standard order view' do
-          spree_post :update, { state: 'confirm' }
+          post :update, { state: 'confirm' }
           expect(response).to redirect_to spree.order_path(order)
         end
       end
@@ -121,13 +121,13 @@ RSpec.describe Spree::CheckoutController, type: :controller do
     it 'does not check registration' do
       allow(controller).to receive(:check_authorization)
       expect(controller).not_to receive(:check_registration)
-      spree_get :registration
+      get :registration
     end
 
     it 'checks if the user is authorized for :edit' do
       expect(controller).to receive(:authorize!).with(:edit, order, token)
       request.cookie_jar.signed[:guest_token] = token
-      spree_get :registration, {}
+      get :registration, {}
     end
   end
 
@@ -138,12 +138,12 @@ RSpec.describe Spree::CheckoutController, type: :controller do
       controller.stub :check_authorization
       order.stub update_attributes: true
       controller.should_not_receive :check_registration
-      spree_put :update_registration, { order: { } }
+      put :update_registration, { order: { } }
     end
 
     it 'renders the registration view if unable to save' do
       allow(controller).to receive(:check_authorization)
-      spree_put :update_registration, { order: { email: 'invalid' } }
+      put :update_registration, { order: { email: 'invalid' } }
       expect(flash[:registration_error]).to eq I18n.t(:email_is_invalid, scope: [:errors, :messages])
       expect(response).to render_template :registration
     end
@@ -151,7 +151,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
     it 'redirects to the checkout_path after saving' do
       allow(order).to receive(:update_attributes) { true }
       allow(controller).to receive(:check_authorization)
-      spree_put :update_registration, { order: { email: 'jobs@spreecommerce.com' } }
+      put :update_registration, { order: { email: 'jobs@spreecommerce.com' } }
       expect(response).to redirect_to spree.checkout_path
     end
 
@@ -159,7 +159,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
       request.cookie_jar.signed[:guest_token] = token
       allow(order).to receive(:update_attributes) { true }
       expect(controller).to receive(:authorize!).with(:edit, order, token)
-      spree_put :update_registration, { order: { email: 'jobs@spreecommerce.com' } }
+      put :update_registration, { order: { email: 'jobs@spreecommerce.com' } }
     end
   end
 end

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spree::ProductsController, type: :controller do
     allow(controller).to receive(:before_save_new_order)
     allow(controller).to receive(:spree_current_user) { user }
     allow(user).to receive(:has_spree_role?) { true }
-    spree_get :show, id: product.to_param
+    get :show, id: product.to_param
     expect(response.status).to eq(200)
   end
 
@@ -15,7 +15,7 @@ RSpec.describe Spree::ProductsController, type: :controller do
     allow(controller).to receive(:before_save_new_order)
     allow(controller).to receive(:spree_current_user) { user }
     allow(user).to receive(:has_spree_role?) { false }
-    spree_get :show, id: product.to_param
+    get :show, id: product.to_param
     expect(response.status).to eq(404)
   end
 end

--- a/spec/controllers/spree/user_passwords_controller_spec.rb
+++ b/spec/controllers/spree/user_passwords_controller_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Spree::UserPasswordsController, type: :controller do
   describe 'GET edit' do
     context 'when the user token has not been specified' do
       it 'redirects to the new session path' do
-        spree_get :edit
+        get :edit
         expect(response).to redirect_to(
           'http://test.host/user/spree_user/sign_in'
         )
       end
 
       it 'flashes an error' do
-        spree_get :edit
+        get :edit
         expect(flash[:alert]).to include(
           "You can't access this page without coming from a password reset " +
           'email'
@@ -24,7 +24,7 @@ RSpec.describe Spree::UserPasswordsController, type: :controller do
 
     context 'when the user token has been specified' do
       it 'does something' do
-        spree_get :edit, reset_password_token: token
+        get :edit, reset_password_token: token
         expect(response.code).to eq('200')
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe Spree::UserPasswordsController, type: :controller do
   context '#update' do
     context 'when updating password with blank password' do
       it 'shows error flash message, sets spree_user with token and re-displays password edit form' do
-        spree_put :update, { spree_user: { password: '', password_confirmation: '', reset_password_token: token } }
+        put :update, { spree_user: { password: '', password_confirmation: '', reset_password_token: token } }
         expect(assigns(:spree_user).kind_of?(Spree::User)).to eq true
         expect(assigns(:spree_user).reset_password_token).to eq token
         expect(flash[:error]).to eq I18n.t(:cannot_be_blank, scope: [:devise, :user_passwords, :spree_user])

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
     let(:password_confirmation) { 'foobar123' }
 
     subject do
-      spree_post(:create,
+      post(:create,
         spree_user: {
           email: 'foobar@example.com',
           password: 'foobar123',

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spree::UserSessionsController, type: :controller do
     let(:password) { 'secret' }
 
     subject do
-      spree_post(:create,
+      post(:create,
         spree_user: {
           email: user.email,
           password: password

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Spree::UsersController, type: :controller do
   context '#load_object' do
     it 'redirects to signup path if user is not found' do
       allow(controller).to receive(:spree_current_user) { nil }
-      spree_put :update, { user: { email: 'foobar@example.com' } }
+      put :update, { user: { email: 'foobar@example.com' } }
       expect(response).to redirect_to spree.login_path
     end
   end
 
   context '#create' do
     it 'creates a new user' do
-      spree_post :create, { user: { email: 'foobar@example.com', password: 'foobar123', password_confirmation: 'foobar123' } }
+      post :create, { user: { email: 'foobar@example.com', password: 'foobar123', password_confirmation: 'foobar123' } }
       expect(assigns[:user].new_record?).to be false
     end
   end
@@ -24,14 +24,14 @@ RSpec.describe Spree::UsersController, type: :controller do
   context '#update' do
     context 'when updating own account' do
       it 'performs update' do
-        spree_put :update, { user: { email: 'mynew@email-address.com' } }
+        put :update, { user: { email: 'mynew@email-address.com' } }
         expect(assigns[:user].email).to eq 'mynew@email-address.com'
         expect(response).to redirect_to spree.account_url(only_path: true)
       end
     end
 
     it 'does not update roles' do
-      spree_put :update, user: { spree_role_ids: [role.id] }
+      put :update, user: { spree_role_ids: [role.id] }
       expect(assigns[:user].spree_roles).to_not include role
     end
   end


### PR DESCRIPTION
These are deprecated as of https://github.com/solidusio/solidus/pull/1330