### PR TITLE
Skip admin override for Solidus >= 1.0

### DIFF
--- a/app/overrides/auth_admin_login_navigation_bar.rb
+++ b/app/overrides/auth_admin_login_navigation_bar.rb
@@ -1,0 +1,8 @@
+Deface::Override.new(
+  virtual_path: "spree/admin/shared/_header",
+  name: "auth_admin_login_navigation_bar",
+  insert_before: "[data-hook='admin_login_navigation_bar'], #admin_login_navigation_bar[data-hook]",
+  partial: "spree/layouts/admin/login_nav",
+  disabled: false,
+  original: '841227d0aedf7909d62237d8778df99100087715'
+)

--- a/app/overrides/auth_admin_login_navigation_bar.rb
+++ b/app/overrides/auth_admin_login_navigation_bar.rb
@@ -1,8 +1,11 @@
-Deface::Override.new(
-  virtual_path: "spree/admin/shared/_header",
-  name: "auth_admin_login_navigation_bar",
-  insert_before: "[data-hook='admin_login_navigation_bar'], #admin_login_navigation_bar[data-hook]",
-  partial: "spree/layouts/admin/login_nav",
-  disabled: false,
-  original: '841227d0aedf7909d62237d8778df99100087715'
-)
+override_required = !Spree.respond_to?(:solidus_version) || Spree.solidus_version < '1.2'
+if override_required
+  Deface::Override.new(
+    virtual_path: "spree/admin/shared/_header",
+    name: "auth_admin_login_navigation_bar",
+    insert_before: "[data-hook='admin_login_navigation_bar'], #admin_login_navigation_bar[data-hook]",
+    partial: "spree/layouts/admin/login_nav",
+    disabled: false,
+    original: '841227d0aedf7909d62237d8778df99100087715'
+  )
+end

--- a/app/overrides/spree/admin/shared/_header/auth_admin_login_navigation_bar.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_header/auth_admin_login_navigation_bar.html.erb.deface
@@ -1,4 +1,0 @@
-<!-- insert_top "[data-hook='admin_login_navigation_bar'], #admin_login_navigation_bar[data-hook]"
-     original '841227d0aedf7909d62237d8778df99100087715' -->
-
-<%= render partial: "spree/layouts/admin/login_nav" %>


### PR DESCRIPTION
We no longer use this override in new versions, so we should skip it.

This should remove the warning:
```
Deface: 1 overrides found for 'spree/admin/shared/_header'
Deface: 'auth_admin_login_navigation_bar' matched 0 times with '[data-hook='admin_login_navigation_bar'], #admin_login_navigation_bar[data-hook]'
```