### PR TITLE
Loading of routes can be disabled through config

### DIFF
--- a/app/models/spree/auth_configuration.rb
+++ b/app/models/spree/auth_configuration.rb
@@ -3,5 +3,7 @@ module Spree
     preference :registration_step, :boolean, default: true
     preference :signout_after_password_change, :boolean, default: true
     preference :confirmable, :boolean, default: false
+    preference :draw_frontend_routes, :boolean, default: true
+    preference :draw_backend_routes, :boolean, default: true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Spree::Core::Engine.routes.draw do
-  if Spree::Auth::Engine.frontend_available?
+  if (
+    Spree::Auth::Engine.frontend_available? &&
+    Spree::Auth::Config.draw_frontend_routes
+  )
+
     devise_for(:spree_user, {
       class_name: 'Spree::User',
       controllers: {
@@ -34,7 +38,11 @@ Spree::Core::Engine.routes.draw do
     resource :account, controller: 'users'
   end
 
-  if Spree::Auth::Engine.backend_available?
+  if (
+    Spree::Auth::Engine.backend_available? &&
+    Spree::Auth::Config.draw_backend_routes
+  )
+
     namespace :admin do
       devise_for(:spree_user, {
         class_name: 'Spree::User',


### PR DESCRIPTION
In some cases, users may wish to override the default routing, or
disable routing entirely for certain endpoints.

This provides configuration options to disable loading those routes even
if the module itself is loaded. This can be setup as follows:

```
Spree::Auth::Config.configure do |config|
  config.draw_backend_routes = false
  config.draw_frontend_routes = false
end
```