### PR TITLE
Add missing translations for already_authenticated

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -7,6 +7,7 @@ de:
       confirmed: Ihr Konto wurde erfolgreich aktiviert.
       send_instructions: 'In ein paar Minuten erhalten Sie eine E-Mail mit Anweisungen, um Ihr Konto zu aktivieren.'
     failure:
+      already_authenticated: Sie sind bereits angemeldet.
       inactive: Ihr Konto wurde noch nicht aktiviert.
       invalid: Ungültige E-Mail-Adresse oder Passwort.
       invalid_token: Ungültiger Authentifizierungsschlüssel.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
       confirmed: Your account was successfully confirmed. You are now signed in.
       send_instructions: You will receive an email with instructions about how to confirm your account in a few minutes.
     failure:
+      already_authenticated: You are already signed in.
       inactive: Your account was not activated yet.
       invalid: Invalid email or password.
       invalid_token: Invalid authentication token.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,6 +5,7 @@ es:
       confirmed: Su cuenta ha sido confirmada. Ahora está conectado.
       send_instructions: Recibirá un email con instrucciones acerca de como confirmar su cuenta en pocos minutos.
     failure:
+      already_authenticated: Ya has iniciado sesión.
       inactive: Su cuenta no ha sido activada aún.
       invalid: Dirección de correo o contraseña no válidos.
       invalid_token: Token de autenticación no válido.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,6 +5,7 @@ fr:
       confirmed: Votre compte a été confirmé. Vous êtes maintenant connecté(e).
       send_instructions: Vous recevrez dans quelques minutes un courriel avec les instructions sur la façon de confirmer votre compte.
     failure:
+      already_authenticated: Vous êtes déjà connecté(e).
       inactive: Votre compte n'a pas encore été activé.
       invalid: Courriel ou mot de passe non valide.
       invalid_token: Jeton d'authentification non valide.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -5,6 +5,7 @@ nl:
       confirmed: Je account is succesvol bevestigd. Je bent nu ingelogd.
       send_instructions: Binnen enkele minuten ontvang je een e-mail om je account te bevestigen.
     failure:
+      already_authenticated: Je bent reeds aangemeld.
       inactive: Je account is nog niet geactiveerd.
       invalid: E-mailadres of wachtwoord is onjuist.
       invalid_token: Verkeerde authenticatie token.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -7,6 +7,7 @@ pt-BR:
       confirmed: Sua conta foi confirmada com sucesso. Agora você está conectado.
       send_instructions: Você receberá um e-mail com instruções sobre como confirmar sua conta em poucos minutos.
     failure:
+      already_authenticated: Você já está autenticado.
       inactive: Sua conta não foi ativada ainda.
       invalid: Email ou senha inválida.
       invalid_token: Token de autenticação inválido.

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -5,6 +5,7 @@ tr:
       confirmed: Hesabınız başarıyla doğrulandı. Oturumunuz açıldı.
       send_instructions: Birkaç dakika içinde hesabınızı nasıl doğrulayacağınızı anlatan bir e-posta alacaksınız.
     failure:
+      already_authenticated: Zaten giriş yaptınız.
       inactive: Hesabınız henüz faal değil.
       invalid: Geçersiz e-posta ya da şifre.
       invalid_token: Geçersiz anahtar.

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -7,6 +7,7 @@ zh-CN:
       confirmed: 账户确认成功，现已登录。
       send_instructions: 稍后您将收到邮件，了解如何确认账户。
     failure:
+      already_authenticated: 登录成功
       inactive: 您的账户尚未激活。
       invalid: 邮箱或密码错误。
       invalid_token: 验证凭证错误。


### PR DESCRIPTION
`devise.failure. already_authenticated` is only present in `it.yml`. This is shown when a user tries to login when he is already signed-in

Translations are taken from: https://github.com/tigrish/devise-i18n