### PR TITLE
Switch to rails 5 spec keyword request syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,12 @@ source "https://rubygems.org"
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 
-if branch == 'master' || branch >= "v2.0"
-  gem "rails-controller-testing", group: :test
+group :test do
+  if branch == 'master' || branch >= "v2.0"
+    gem "rails-controller-testing"
+  else
+    gem "rails_test_params_backport"
+  end
 end
 
 gem 'pg'

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe Spree::CheckoutController, type: :controller do
         before { allow(controller).to receive(:spree_current_user) { user } }
 
         it 'proceeds to the first checkout step' do
-          get :edit, { state: 'address' }
+          get :edit, params: { state: 'address' }
           expect(response).to render_template :edit
         end
       end
 
       context 'when not authenticated as guest' do
         it 'redirects to registration step' do
-          get :edit, { state: 'address' }
+          get :edit, params: { state: 'address' }
           expect(response).to redirect_to spree.checkout_registration_path
         end
       end
@@ -33,7 +33,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
         before { order.email = 'guest@solidus.io' }
 
         it 'proceeds to the first checkout step' do
-          get :edit, { state: 'address' }
+          get :edit, params: { state: 'address' }
           expect(response).to render_template :edit
         end
 
@@ -47,7 +47,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
           end
 
           it 'redirects to registration step' do
-            get :edit, { state: 'address' }
+            get :edit, params: { state: 'address' }
             expect(response).to redirect_to spree.checkout_registration_path
           end
         end
@@ -63,14 +63,14 @@ RSpec.describe Spree::CheckoutController, type: :controller do
         before { allow(controller).to receive(:spree_current_user) { user } }
 
         it 'proceeds to the first checkout step' do
-          get :edit, { state: 'address' }
+          get :edit, params: { state: 'address' }
           expect(response).to render_template :edit
         end
       end
 
       context 'when authenticated as guest' do
         it 'proceeds to the first checkout step' do
-          get :edit, { state: 'address' }
+          get :edit, params: { state: 'address' }
           expect(response).to render_template :edit
         end
       end
@@ -92,7 +92,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
 
         it 'redirects to the tokenized order view' do
           request.cookie_jar.signed[:guest_token] = 'ABC'
-          post :update, { state: 'confirm' }
+          post :update, params: { state: 'confirm' }
           expect(response).to redirect_to spree.token_order_path(order, 'ABC')
           expect(flash.notice).to eq Spree.t(:order_processed_successfully)
         end
@@ -106,7 +106,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
         end
 
         it 'redirects to the standard order view' do
-          post :update, { state: 'confirm' }
+          post :update, params: { state: 'confirm' }
           expect(response).to redirect_to spree.order_path(order)
         end
       end
@@ -122,12 +122,12 @@ RSpec.describe Spree::CheckoutController, type: :controller do
     it 'checks if the user is authorized for :edit' do
       expect(controller).to receive(:authorize!).with(:edit, order, token)
       request.cookie_jar.signed[:guest_token] = token
-      get :registration, {}
+      get :registration, params: {}
     end
   end
 
   context '#update_registration' do
-    subject { put :update_registration, { order: { email: email } } }
+    subject { put :update_registration, params: { order: { email: email } } }
     let(:email) { 'foo@example.com' }
 
     it 'does not check registration' do
@@ -179,7 +179,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
       let(:cookie_token) { 'lol_no_access' }
 
       it 'redirects to login' do
-        put :update_registration, { order: { email: 'foo@example.com' } }
+        put :update_registration, params: { order: { email: 'foo@example.com' } }
         expect(response).to redirect_to(login_path)
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
       let(:cookie_token) { nil }
 
       it 'redirects to login' do
-        put :update_registration, { order: { email: 'foo@example.com' } }
+        put :update_registration, params: { order: { email: 'foo@example.com' } }
         expect(response).to redirect_to(login_path)
       end
     end

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spree::ProductsController, type: :controller do
     allow(controller).to receive(:before_save_new_order)
     allow(controller).to receive(:spree_current_user) { user }
     allow(user).to receive(:has_spree_role?) { true }
-    get :show, id: product.to_param
+    get :show, params: { id: product.to_param }
     expect(response.status).to eq(200)
   end
 
@@ -15,7 +15,7 @@ RSpec.describe Spree::ProductsController, type: :controller do
     allow(controller).to receive(:before_save_new_order)
     allow(controller).to receive(:spree_current_user) { user }
     allow(user).to receive(:has_spree_role?) { false }
-    get :show, id: product.to_param
+    get :show, params: { id: product.to_param }
     expect(response.status).to eq(404)
   end
 end

--- a/spec/controllers/spree/user_passwords_controller_spec.rb
+++ b/spec/controllers/spree/user_passwords_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Spree::UserPasswordsController, type: :controller do
 
     context 'when the user token has been specified' do
       it 'does something' do
-        get :edit, reset_password_token: token
+        get :edit, params: { reset_password_token: token }
         expect(response.code).to eq('200')
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe Spree::UserPasswordsController, type: :controller do
   context '#update' do
     context 'when updating password with blank password' do
       it 'shows error flash message, sets spree_user with token and re-displays password edit form' do
-        put :update, { spree_user: { password: '', password_confirmation: '', reset_password_token: token } }
+        put :update, params: { spree_user: { password: '', password_confirmation: '', reset_password_token: token } }
         expect(assigns(:spree_user).kind_of?(Spree::User)).to eq true
         expect(assigns(:spree_user).reset_password_token).to eq token
         expect(flash[:error]).to eq I18n.t(:cannot_be_blank, scope: [:devise, :user_passwords, :spree_user])

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -12,12 +12,15 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
     let(:password_confirmation) { 'foobar123' }
 
     subject do
-      post(:create,
-        spree_user: {
-          email: 'foobar@example.com',
-          password: 'foobar123',
-          password_confirmation: password_confirmation
-        })
+      post(:create, {
+        params: {
+          spree_user: {
+            email: 'foobar@example.com',
+            password: 'foobar123',
+            password_confirmation: password_confirmation
+          }
+        }
+      })
     end
 
     context 'when user created successfuly' do

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe Spree::UserSessionsController, type: :controller do
     let(:password) { 'secret' }
 
     subject do
-      post(:create,
-        spree_user: {
-          email: user.email,
-          password: password
-        },
-        format: format)
+      post(:create, {
+        params: {
+          spree_user: {
+            email: user.email,
+            password: password
+          },
+          format: format
+        }
+      })
     end
 
     context "when using correct login information" do

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Spree::UsersController, type: :controller do
   context '#load_object' do
     it 'redirects to signup path if user is not found' do
       allow(controller).to receive(:spree_current_user) { nil }
-      put :update, { user: { email: 'foobar@example.com' } }
+      put :update, params: { user: { email: 'foobar@example.com' } }
       expect(response).to redirect_to spree.login_path
     end
   end
 
   context '#create' do
     it 'creates a new user' do
-      post :create, { user: { email: 'foobar@example.com', password: 'foobar123', password_confirmation: 'foobar123' } }
+      post :create, params: { user: { email: 'foobar@example.com', password: 'foobar123', password_confirmation: 'foobar123' } }
       expect(assigns[:user].new_record?).to be false
     end
   end
@@ -24,14 +24,14 @@ RSpec.describe Spree::UsersController, type: :controller do
   context '#update' do
     context 'when updating own account' do
       it 'performs update' do
-        put :update, { user: { email: 'mynew@email-address.com' } }
+        put :update, params: { user: { email: 'mynew@email-address.com' } }
         expect(assigns[:user].email).to eq 'mynew@email-address.com'
         expect(response).to redirect_to spree.account_url(only_path: true)
       end
     end
 
     it 'does not update roles' do
-      put :update, user: { spree_role_ids: [role.id] }
+      put :update, params: { user: { spree_role_ids: [role.id] } }
       expect(assigns[:user].spree_roles).to_not include role
     end
   end


### PR DESCRIPTION
This adds the `rails_test_params_backport` gem which allows us to write requests in specs using the `:params`, `:headers` and `:env` options introduced in Rails 5.

This allows the same specs to run on both rails 4.2 and rails 5 without generating deprecation warnings.