### PR TITLE
Change deface dependency from `~> 1.0.0` to `~> 1.0`

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "solidus_core", solidus_version
   s.add_dependency "devise", '~> 4.1'
   s.add_dependency "devise-encryptable", "0.2.0"
-  s.add_dependency 'deface', '~> 1.0.0'
+  s.add_dependency 'deface', '~> 1.0'
 
   s.add_dependency "json"
   s.add_dependency "multi_json"


### PR DESCRIPTION
Was the restriction here intentional?

Original PR adding it was https://github.com/solidusio/solidus_auth_devise/pull/19