### PR TITLE
Add migration version to migrations

### DIFF
--- a/db/migrate/20101026184949_create_users.rb
+++ b/db/migrate/20101026184949_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def up
     unless table_exists?("spree_users")
       create_table "spree_users", :force => true do |t|

--- a/db/migrate/20101026184949_create_users.rb
+++ b/db/migrate/20101026184949_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration[4.2]
+class CreateUsers < Spree::Auth.rails_4_2_compatible_migration_class
   def up
     unless table_exists?("spree_users")
       create_table "spree_users", :force => true do |t|

--- a/db/migrate/20101026184950_rename_columns_for_devise.rb
+++ b/db/migrate/20101026184950_rename_columns_for_devise.rb
@@ -1,4 +1,4 @@
-class RenameColumnsForDevise < ActiveRecord::Migration
+class RenameColumnsForDevise < ActiveRecord::Migration[4.2]
   def up
     return if column_exists?(:spree_users, :password_salt)
     rename_column :spree_users, :crypted_password, :encrypted_password

--- a/db/migrate/20101026184950_rename_columns_for_devise.rb
+++ b/db/migrate/20101026184950_rename_columns_for_devise.rb
@@ -1,4 +1,4 @@
-class RenameColumnsForDevise < ActiveRecord::Migration[4.2]
+class RenameColumnsForDevise < Spree::Auth.rails_4_2_compatible_migration_class
   def up
     return if column_exists?(:spree_users, :password_salt)
     rename_column :spree_users, :crypted_password, :encrypted_password

--- a/db/migrate/20101214150824_convert_user_remember_field.rb
+++ b/db/migrate/20101214150824_convert_user_remember_field.rb
@@ -1,4 +1,4 @@
-class ConvertUserRememberField < ActiveRecord::Migration
+class ConvertUserRememberField < ActiveRecord::Migration[4.2]
   def up
     remove_column :spree_users, :remember_created_at
     add_column :spree_users, :remember_created_at, :datetime

--- a/db/migrate/20101214150824_convert_user_remember_field.rb
+++ b/db/migrate/20101214150824_convert_user_remember_field.rb
@@ -1,4 +1,4 @@
-class ConvertUserRememberField < ActiveRecord::Migration[4.2]
+class ConvertUserRememberField < Spree::Auth.rails_4_2_compatible_migration_class
   def up
     remove_column :spree_users, :remember_created_at
     add_column :spree_users, :remember_created_at, :datetime

--- a/db/migrate/20120203010234_add_reset_password_sent_at_to_spree_users.rb
+++ b/db/migrate/20120203010234_add_reset_password_sent_at_to_spree_users.rb
@@ -1,4 +1,4 @@
-class AddResetPasswordSentAtToSpreeUsers < ActiveRecord::Migration
+class AddResetPasswordSentAtToSpreeUsers < ActiveRecord::Migration[4.2]
   def change
     Spree::User.reset_column_information
     unless Spree::User.column_names.include?("reset_password_sent_at")

--- a/db/migrate/20120203010234_add_reset_password_sent_at_to_spree_users.rb
+++ b/db/migrate/20120203010234_add_reset_password_sent_at_to_spree_users.rb
@@ -1,4 +1,4 @@
-class AddResetPasswordSentAtToSpreeUsers < ActiveRecord::Migration[4.2]
+class AddResetPasswordSentAtToSpreeUsers < Spree::Auth.rails_4_2_compatible_migration_class
   def change
     Spree::User.reset_column_information
     unless Spree::User.column_names.include?("reset_password_sent_at")

--- a/db/migrate/20120605211305_make_users_email_index_unique.rb
+++ b/db/migrate/20120605211305_make_users_email_index_unique.rb
@@ -1,4 +1,4 @@
-class MakeUsersEmailIndexUnique < ActiveRecord::Migration
+class MakeUsersEmailIndexUnique < ActiveRecord::Migration[4.2]
   def up
     add_index "spree_users", ["email"], :name => "email_idx_unique", :unique => true
   end

--- a/db/migrate/20120605211305_make_users_email_index_unique.rb
+++ b/db/migrate/20120605211305_make_users_email_index_unique.rb
@@ -1,4 +1,4 @@
-class MakeUsersEmailIndexUnique < ActiveRecord::Migration[4.2]
+class MakeUsersEmailIndexUnique < Spree::Auth.rails_4_2_compatible_migration_class
   def up
     add_index "spree_users", ["email"], :name => "email_idx_unique", :unique => true
   end

--- a/db/migrate/20140904000425_add_deleted_at_to_users.rb
+++ b/db/migrate/20140904000425_add_deleted_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToUsers < ActiveRecord::Migration
+class AddDeletedAtToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_users, :deleted_at, :datetime
     add_index :spree_users, :deleted_at

--- a/db/migrate/20140904000425_add_deleted_at_to_users.rb
+++ b/db/migrate/20140904000425_add_deleted_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToUsers < ActiveRecord::Migration[4.2]
+class AddDeletedAtToUsers < Spree::Auth.rails_4_2_compatible_migration_class
   def change
     add_column :spree_users, :deleted_at, :datetime
     add_index :spree_users, :deleted_at

--- a/db/migrate/20141002154641_add_confirmable_to_users.rb
+++ b/db/migrate/20141002154641_add_confirmable_to_users.rb
@@ -1,4 +1,4 @@
-class AddConfirmableToUsers < ActiveRecord::Migration
+class AddConfirmableToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_users, :confirmation_token, :string
     add_column :spree_users, :confirmed_at, :datetime

--- a/db/migrate/20141002154641_add_confirmable_to_users.rb
+++ b/db/migrate/20141002154641_add_confirmable_to_users.rb
@@ -1,4 +1,4 @@
-class AddConfirmableToUsers < ActiveRecord::Migration[4.2]
+class AddConfirmableToUsers < Spree::Auth.rails_4_2_compatible_migration_class
   def change
     add_column :spree_users, :confirmation_token, :string
     add_column :spree_users, :confirmed_at, :datetime

--- a/lib/spree/auth/devise.rb
+++ b/lib/spree/auth/devise.rb
@@ -8,6 +8,14 @@ module Spree
     def self.config(&block)
       yield(Spree::Auth::Config)
     end
+
+    def self.rails_4_2_compatible_migration_class
+      if Rails.gem_version >= Gem::Version.new('5')
+        ActiveRecord::Migration[4.2]
+      else
+        ActiveRecord::Migration
+      end
+    end
   end
 end
 


### PR DESCRIPTION
To eliminate this deprecation warning:

    DEPRECATION WARNING: Directly inheriting from ActiveRecord::Migration is deprecated. Please specify the Rails release the migration was written for