### PR TITLE
Fix warnings on Rails 5.0, support Rails 5.1

### DIFF
--- a/db/migrate/20101026184949_create_users.rb
+++ b/db/migrate/20101026184949_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < SolidusSupport::Migration[4.2]
   def up
     unless table_exists?("spree_users")
       create_table "spree_users", :force => true do |t|

--- a/db/migrate/20101026184950_rename_columns_for_devise.rb
+++ b/db/migrate/20101026184950_rename_columns_for_devise.rb
@@ -1,4 +1,4 @@
-class RenameColumnsForDevise < ActiveRecord::Migration
+class RenameColumnsForDevise < SolidusSupport::Migration[4.2]
   def up
     return if column_exists?(:spree_users, :password_salt)
     rename_column :spree_users, :crypted_password, :encrypted_password

--- a/db/migrate/20101214150824_convert_user_remember_field.rb
+++ b/db/migrate/20101214150824_convert_user_remember_field.rb
@@ -1,4 +1,4 @@
-class ConvertUserRememberField < ActiveRecord::Migration
+class ConvertUserRememberField < SolidusSupport::Migration[4.2]
   def up
     remove_column :spree_users, :remember_created_at
     add_column :spree_users, :remember_created_at, :datetime

--- a/db/migrate/20120203010234_add_reset_password_sent_at_to_spree_users.rb
+++ b/db/migrate/20120203010234_add_reset_password_sent_at_to_spree_users.rb
@@ -1,4 +1,4 @@
-class AddResetPasswordSentAtToSpreeUsers < ActiveRecord::Migration
+class AddResetPasswordSentAtToSpreeUsers < SolidusSupport::Migration[4.2]
   def change
     Spree::User.reset_column_information
     unless Spree::User.column_names.include?("reset_password_sent_at")

--- a/db/migrate/20120605211305_make_users_email_index_unique.rb
+++ b/db/migrate/20120605211305_make_users_email_index_unique.rb
@@ -1,4 +1,4 @@
-class MakeUsersEmailIndexUnique < ActiveRecord::Migration
+class MakeUsersEmailIndexUnique < SolidusSupport::Migration[4.2]
   def up
     add_index "spree_users", ["email"], :name => "email_idx_unique", :unique => true
   end

--- a/db/migrate/20140904000425_add_deleted_at_to_users.rb
+++ b/db/migrate/20140904000425_add_deleted_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToUsers < ActiveRecord::Migration
+class AddDeletedAtToUsers < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_users, :deleted_at, :datetime
     add_index :spree_users, :deleted_at

--- a/db/migrate/20141002154641_add_confirmable_to_users.rb
+++ b/db/migrate/20141002154641_add_confirmable_to_users.rb
@@ -1,4 +1,4 @@
-class AddConfirmableToUsers < ActiveRecord::Migration
+class AddConfirmableToUsers < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_users, :confirmation_token, :string
     add_column :spree_users, :confirmed_at, :datetime

--- a/lib/solidus_auth_devise.rb
+++ b/lib/solidus_auth_devise.rb
@@ -1,4 +1,5 @@
 require "spree_core"
+require "solidus_support"
 require "spree/auth/devise"
 require "spree/authentication_helpers"
 require "sass/rails"

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   solidus_version = [">= 1.0.6", "< 3"]
 
   s.add_dependency "solidus_core", solidus_version
+  s.add_dependency "solidus_support"
   s.add_dependency "devise", '~> 4.1'
   s.add_dependency "devise-encryptable", "0.2.0"
   s.add_dependency 'deface', '~> 1.0'


### PR DESCRIPTION
Refs: #82, #84 

Using `ActiveRecord::Migration` directly generates warnings on rails 5.0 and errors on rails 5.1. Specifying a version still errors on rails 4.2.

This uses the new `solidus_support` gem, which has a [help to work around this issue](https://github.com/solidusio/solidus_support#solidussupportmigration).

We should be able to use this in the other extensions as well