### PR TITLE
Do not require core email validator

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,4 +1,3 @@
-require 'spree/core/validators/email'
 Spree::CheckoutController.class_eval do
   prepend_before_action :check_registration,
     except: [:registration, :update_registration]


### PR DESCRIPTION
Since c199b6c1084aa19d36ad79448b48b40e550ebab9 we do not validate the email with the validator provided by core anymore.