### PR TITLE
Wrap use of `helper_method` in `respond_to?`

### DIFF
--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -1,12 +1,14 @@
 module Spree
   module AuthenticationHelpers
     def self.included(receiver)
-      receiver.send :helper_method, :spree_current_user
+      if receiver.send(:respond_to?, :helper_method)
+        receiver.send(:helper_method, :spree_current_user)
 
-      if Spree::Auth::Engine.frontend_available?
-        receiver.send :helper_method, :spree_login_path
-        receiver.send :helper_method, :spree_signup_path
-        receiver.send :helper_method, :spree_logout_path
+        if Spree::Auth::Engine.frontend_available?
+          receiver.send(:helper_method, :spree_login_path)
+          receiver.send(:helper_method, :spree_signup_path)
+          receiver.send(:helper_method, :spree_logout_path)
+        end
       end
     end
 


### PR DESCRIPTION
This is considered the "safe" way to invoke `helper_method` in Rails
engines, as it is not available in some contexts, for example in
API-only applications.

Fixes #90.