### PR TITLE
Remove use of deprecated `bypass` opt for sign_in

### DIFF
--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -27,7 +27,9 @@ class Spree::UsersController < Spree::StoreController
     if @user.update_attributes(user_params)
       if params[:user][:password].present?
         # this logic needed b/c devise wants to log us out after password changes
-        sign_in(@user, event: :authentication, bypass: !Spree::Auth::Config[:signout_after_password_change])
+        unless Spree::Auth::Config[:signout_after_password_change]
+          bypass_sign_in(@user)
+        end
       end
       redirect_to spree.account_url, notice: Spree.t(:account_updated)
     else


### PR DESCRIPTION
This updates the logic in the Spree::UsersController to remove the usage of the deprecated `bypass` option for Devise's `sign_in` helper.