### PR TITLE
Only apply frontend override if frontend present

### DIFF
--- a/app/overrides/auth_shared_login_bar.rb
+++ b/app/overrides/auth_shared_login_bar.rb
@@ -1,8 +1,10 @@
-Deface::Override.new(
-  virtual_path: "spree/shared/_nav_bar",
-  name: "auth_shared_login_bar",
-  insert_before: "li#search-bar",
-  partial: "spree/shared/login_bar",
-  disabled: false,
-  original: 'eb3fa668cd98b6a1c75c36420ef1b238a1fc55ac'
-)
+if Spree::Auth::Engine.frontend_available?
+  Deface::Override.new(
+    virtual_path: "spree/shared/_nav_bar",
+    name: "auth_shared_login_bar",
+    insert_before: "li#search-bar",
+    partial: "spree/shared/login_bar",
+    disabled: false,
+    original: 'eb3fa668cd98b6a1c75c36420ef1b238a1fc55ac'
+  )
+end


### PR DESCRIPTION
Closes #85.

This commit updates the Deface override providing the shared login bar for `solidus_frontend` to only do so if `solidus_frontend` is present. This prevents compilation errors from Deface in stores that do not include `solidus_frontend`.