### PR TITLE
Reset api key when assigning password

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -8,7 +8,11 @@ module Spree
 
     acts_as_paranoid
     after_destroy :scramble_email_and_password
-    before_update { generate_spree_api_key if encrypted_password_changed? && spree_api_key.present? }
+
+    def password=(new_password)
+      generate_spree_api_key if new_password.present? && spree_api_key.present?
+      super
+    end
 
     has_many :orders
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,18 +18,32 @@ RSpec.describe Spree::User, type: :model do
     it "regenerates a spree api key on successful password change" do
       user.generate_spree_api_key!
 
-      user.password = "123456678"
-      user.password_confirmation = "123456678"
-      expect { user.save! }.to change(user, :spree_api_key)
+      expect {
+        user.password = "123456678"
+        user.password_confirmation = "123456678"
+        user.save!
+      }.to change(user, :spree_api_key)
       expect(user.spree_api_key).to be_present
+    end
+
+    it "does not generate a spree api key if password is empty" do
+      user.generate_spree_api_key!
+
+      expect {
+        user.password = ""
+        user.password_confirmation = ""
+        user.save!
+      }.not_to change(user, :spree_api_key)
     end
 
     it "does not generate a spree api key on password change if no key existed previously" do
       user.clear_spree_api_key!
 
-      user.password = "123456678"
-      user.password_confirmation = "123456678"
-      expect { user.save! }.not_to change(user, :spree_api_key)
+      expect {
+        user.password = "123456678"
+        user.password_confirmation = "123456678"
+        user.save!
+      }.not_to change(user, :spree_api_key)
       expect(user.reload.spree_api_key).to be_nil
     end
   end


### PR DESCRIPTION
Instead of resetting it when saving a new password. This avoids adding an ActiveRecord callback which in turn needs to use the `_changed?` api (which has changing in Rails 5.1).

This avoids a warning on Rails 5.1