### PR TITLE
match logout route to devise configuration

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Spree::Core::Engine.routes.draw do
     devise_scope :spree_user do
       get '/login', to: 'user_sessions#new', as: :login
       post '/login', to: 'user_sessions#create', as: :create_new_session
-      get '/logout', to: 'user_sessions#destroy', as: :logout
+      match '/logout', to: 'user_sessions#destroy', as: :logout, via: Devise.sign_out_via
       get '/signup', to: 'user_registrations#new', as: :signup
       post '/signup', to: 'user_registrations#create', as: :registration
       get '/password/recover', to: 'user_passwords#new', as: :recover_password


### PR DESCRIPTION
Noticed that when I did:

```ruby
Devise.setup do |config|
  config.sign_out_via = :delete
end
```

Things wouldn't work when I logged out and the `DELETE /logout` route didn't exist. This PR makes the routes in Solidus Auth Devise more closely adhere to what is also configured for Devise as well.