### PR TITLE
Remove references to dash

### DIFF
--- a/lib/controllers/frontend/spree/user_confirmations_controller.rb
+++ b/lib/controllers/frontend/spree/user_confirmations_controller.rb
@@ -1,10 +1,6 @@
 class Spree::UserConfirmationsController < Devise::ConfirmationsController
   helper 'spree/base', 'spree/store'
 
-  if Spree::Auth::Engine.dash_available?
-    helper 'spree/analytics'
-  end
-
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order

--- a/lib/controllers/frontend/spree/user_passwords_controller.rb
+++ b/lib/controllers/frontend/spree/user_passwords_controller.rb
@@ -1,10 +1,6 @@
 class Spree::UserPasswordsController < Devise::PasswordsController
   helper 'spree/base', 'spree/store'
 
-  if Spree::Auth::Engine.dash_available?
-    helper 'spree/analytics'
-  end
-
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -1,10 +1,6 @@
 class Spree::UserRegistrationsController < Devise::RegistrationsController
   helper 'spree/base', 'spree/store'
 
-  if Spree::Auth::Engine.dash_available?
-    helper 'spree/analytics'
-  end
-
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Common
   include Spree::Core::ControllerHelpers::Order

--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -1,8 +1,5 @@
 class Spree::UserSessionsController < Devise::SessionsController
   helper 'spree/base', 'spree/store'
-  if Spree::Auth::Engine.dash_available?
-    helper 'spree/analytics'
-  end
 
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Common

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -70,10 +70,6 @@ module Spree
         defined?(Spree::Backend::Engine) == "constant"
       end
 
-      def self.dash_available?
-        defined?(Spree::Dash::Engine) == "constant"
-      end
-
       def self.frontend_available?
         defined?(Spree::Frontend::Engine) == "constant"
       end


### PR DESCRIPTION
Dash refers to the old Jirafe dashboard, which was removed from spree in 2013.