### PR TITLE
Add ffaker dependency to gemspec

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -26,18 +26,18 @@ Gem::Specification.new do |s|
   s.add_dependency "devise-encryptable", "0.2.0"
   s.add_dependency 'deface', '~> 1.0'
 
+  s.add_development_dependency "capybara", "~> 2.14"
+  s.add_development_dependency "capybara-screenshot"
+  s.add_development_dependency "coffee-rails"
+  s.add_development_dependency "database_cleaner", "~> 1.6"
+  s.add_development_dependency "factory_girl", "~> 4.4"
+  s.add_development_dependency "ffaker"
+  s.add_development_dependency "poltergeist", "~> 1.5"
+  s.add_development_dependency "rspec-rails", "~> 3.3"
+  s.add_development_dependency "sass-rails"
+  s.add_development_dependency "shoulda-matchers", "~> 3.1"
+  s.add_development_dependency "simplecov", "~> 0.14"
   s.add_development_dependency "solidus_backend", solidus_version
   s.add_development_dependency "solidus_frontend", solidus_version
-  s.add_development_dependency "rspec-rails", "~> 3.3"
-  s.add_development_dependency "simplecov", "~> 0.14"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "sass-rails"
-  s.add_development_dependency "coffee-rails"
-  s.add_development_dependency "shoulda-matchers", "~> 3.1"
-  s.add_development_dependency "factory_girl", "~> 4.4"
-  s.add_development_dependency "capybara", "~> 2.14"
-  s.add_development_dependency "poltergeist", "~> 1.5"
-  s.add_development_dependency "database_cleaner", "~> 1.6"
-  s.add_development_dependency "capybara-screenshot"
-  s.add_development_dependency "ffaker"
 end

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "poltergeist", "~> 1.5"
   s.add_development_dependency "database_cleaner", "~> 1.6"
   s.add_development_dependency "capybara-screenshot"
+  s.add_development_dependency "ffaker"
 end


### PR DESCRIPTION
ffaker was removed as a runtime dependency of Solidus.

polyglot (which is a dependency of deface) is raising a LoadError when
it tries to require ffaker, which is not defined.

PR removing ffaker from Solidus:
solidusio/solidus#2140

I only add ffaker and alphabetize the dev dependencies in this PR.