### PR TITLE
Stop raising an exception when callback in UsersController is undefined

### DIFF
--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -1,5 +1,5 @@
 class Spree::UsersController < Spree::StoreController
-  skip_before_action :set_current_order, only: :show
+  skip_before_action :set_current_order, only: :show, raise: false
   prepend_before_action :load_object, only: [:show, :edit, :update]
   prepend_before_action :authorize_actions, only: :new
 


### PR DESCRIPTION
The specs are failing because `set_current_order` is not defined as a
process_action callback. This used to be the case but then it was
removed from Solidus.

PR removing this callback:
https://github.com/solidusio/solidus/pull/2185