### PR TITLE
Drop Solidus v1.0, v1.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v1.0 DB=postgres
-    - SOLIDUS_BRANCH=v1.1 DB=postgres
     - SOLIDUS_BRANCH=v1.2 DB=postgres
     - SOLIDUS_BRANCH=v1.3 DB=postgres
     - SOLIDUS_BRANCH=v1.4 DB=postgres
@@ -14,8 +12,6 @@ env:
     - SOLIDUS_BRANCH=v2.2 DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v1.0 DB=mysql
-    - SOLIDUS_BRANCH=v1.1 DB=mysql
     - SOLIDUS_BRANCH=v1.2 DB=mysql
     - SOLIDUS_BRANCH=v1.3 DB=mysql
     - SOLIDUS_BRANCH=v1.4 DB=mysql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master (unreleased)
 
+* Drop support for Solidus v1.0 and v1.1
+
 ## Solidus Auth Devise v1.6.4 (2017-07-24)
 
 * Fix error trying to call helper_method in api-only applications

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  solidus_version = [">= 1.0.6", "< 3"]
+  solidus_version = [">= 1.2.0", "< 3"]
 
   s.add_dependency "solidus_core", solidus_version
   s.add_dependency "solidus_support", ">= 0.1.3"


### PR DESCRIPTION
There have been some difficulties reproducing the build errors against Solidus v1.0 and v1.1.
Users that need support for Solidus v1.0 and v1.1 can use solidus_auth_devise v1.6.4.

Please let me know if there should be more detail given to the CHANGELOG entry.