### PR TITLE
Don't require deface for solidus 2.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master (unreleased)
 
+* Avoid requiring deface on Solidus 2.5+
+
 ## Solidus Auth Devise v2.0.0 (2017-09-20)
 
 * Drop support for Solidus v1.0 and v1.1

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,6 @@ group :development, :test do
   gem "pry-rails"
 end
 
+gem 'deface', require: false
+
 gemspec

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Just add this line to your `Gemfile`:
 
 ```ruby
 gem "solidus_auth_devise"
+
+# For Solidus versions < 2.5
+# gem 'deface'
 ```
 
 Then, run `bundle install`.

--- a/app/overrides/auth_admin_login_navigation_bar.rb
+++ b/app/overrides/auth_admin_login_navigation_bar.rb
@@ -1,5 +1,4 @@
-override_required = !Spree.respond_to?(:solidus_version) || Spree.solidus_version < '1.2'
-if override_required
+if SolidusSupport.solidus_gem_version < Gem::Version.new('1.2')
   Deface::Override.new(
     virtual_path: "spree/admin/shared/_header",
     name: "auth_admin_login_navigation_bar",

--- a/app/overrides/auth_shared_login_bar.rb
+++ b/app/overrides/auth_shared_login_bar.rb
@@ -1,9 +1,9 @@
-if SolidusSupport.frontend_available?
+if SolidusSupport.frontend_available? && SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
   Deface::Override.new(
     virtual_path: "spree/shared/_nav_bar",
     name: "auth_shared_login_bar",
     insert_before: "li#search-bar",
-    partial: "spree/shared/login_bar",
+    partial: "spree/shared/login_bar_items",
     disabled: false,
     original: 'eb3fa668cd98b6a1c75c36420ef1b238a1fc55ac'
   )

--- a/lib/solidus_auth_devise.rb
+++ b/lib/solidus_auth_devise.rb
@@ -2,4 +2,12 @@ require "spree_core"
 require "solidus_support"
 require "spree/auth/devise"
 require "spree/authentication_helpers"
-require "deface"
+
+if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
+  begin
+    require "deface"
+  rescue LoadError
+    warn "deface is required to run solidus_auth_devise with solidus versions < 2.5. Please add deface to your Gemfile"
+    raise
+  end
+end

--- a/lib/views/frontend/spree/shared/_login_bar.html.erb
+++ b/lib/views/frontend/spree/shared/_login_bar.html.erb
@@ -1,6 +1,2 @@
-<% if spree_current_user %>
-  <li><%= link_to Spree.t(:my_account), spree.account_path %></li>
-  <li><%= link_to Spree.t(:logout), spree.logout_path %></li>
-<% else %>
-  <li id="link-to-login"><%= link_to Spree.t(:login), spree.login_path %></li>
-<% end %>
+<% Spree::Deprecation.warn "spree/shared/login_bar has moved to spree/shared/login_bar_items" %>
+<%= render 'spree/shared/login_bar_items' %>

--- a/lib/views/frontend/spree/shared/_login_bar_items.html.erb
+++ b/lib/views/frontend/spree/shared/_login_bar_items.html.erb
@@ -1,0 +1,6 @@
+<% if spree_current_user %>
+  <li><%= link_to Spree.t(:my_account), spree.account_path %></li>
+  <li><%= link_to Spree.t(:logout), spree.logout_path %></li>
+<% else %>
+  <li id="link-to-login"><%= link_to Spree.t(:login), spree.login_path %></li>
+<% end %>

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency "solidus_support", ">= 0.1.3"
   s.add_dependency "devise", '~> 4.1'
   s.add_dependency "devise-encryptable", "0.2.0"
-  s.add_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency "capybara", "~> 2.14"
   s.add_development_dependency "capybara-screenshot"


### PR DESCRIPTION
Solidus now renders an empty spree/shared/login_bar_items partial which we can replace instead of needing deface.

To try and prevent compatibility issues, this partial is named login_bar_items instead of login_bar so that users on older versions of auth_devise won't accidentally have two copies of the login menu in their nav.

The old login_bar partial now renders login_bar and issues a warning in case it was being rendered from custom frontend code.