### PR TITLE
update spec according new solidus behaviour for 404

### DIFF
--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -15,7 +15,13 @@ RSpec.describe Spree::ProductsController, type: :controller do
     allow(controller).to receive(:before_save_new_order)
     allow(controller).to receive(:spree_current_user) { user }
     allow(user).to receive(:has_spree_role?) { false }
-    get :show, params: { id: product.to_param }
-    expect(response.status).to eq(404)
+    if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
+      get :show, params: { id: product.to_param }
+      expect(response.status).to eq(404)
+    else
+      expect {
+        get :show, params: { id: product.to_param }
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 end


### PR DESCRIPTION
Since https://github.com/solidusio/solidus/pull/2329 don't rescue when record not found with 404.
This just update the specs according that.