### PR TITLE
Disable backend footer profile edit link if role cannot edit users

### DIFF
--- a/lib/views/backend/spree/admin/shared/_navigation_footer.html.erb
+++ b/lib/views/backend/spree/admin/shared/_navigation_footer.html.erb
@@ -1,9 +1,16 @@
 <% if spree_current_user %>
   <ul id="login-nav" class="admin-login-nav">
     <li data-hook="user-account-link">
-      <%= link_to spree.edit_admin_user_path(spree_current_user) do %>
-        <i class='fa fa-user'></i>
-        <%= spree_current_user.email %>
+      <% if can?(:admin, try_spree_current_user) %>
+        <%= link_to spree.edit_admin_user_path(try_spree_current_user) do %>
+          <i class='fa fa-user'></i>
+          <%= try_spree_current_user.email %>
+        <% end %>
+      <% else %>
+        <a>
+          <i class='fa fa-user'></i>
+          <%= try_spree_current_user.email %>
+        </a>
       <% end %>
     </li>
     <li data-hook="user-logout-link">


### PR DESCRIPTION
A user with a role that can access the backend main page but has no permissions to edit users will get a misleading "Authorization Failure" error.
With this fix the user will be cleanly routed to the main page without displaying any errors.