### PR TITLE
Fix factory girl dependency for Solidus < 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v1.2 DB=postgres
-    - SOLIDUS_BRANCH=v1.3 DB=postgres
-    - SOLIDUS_BRANCH=v1.4 DB=postgres
-    - SOLIDUS_BRANCH=v2.0 DB=postgres
-    - SOLIDUS_BRANCH=v2.1 DB=postgres
     - SOLIDUS_BRANCH=v2.2 DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
@@ -16,11 +11,6 @@ env:
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v1.2 DB=mysql
-    - SOLIDUS_BRANCH=v1.3 DB=mysql
-    - SOLIDUS_BRANCH=v1.4 DB=mysql
-    - SOLIDUS_BRANCH=v2.0 DB=mysql
-    - SOLIDUS_BRANCH=v2.1 DB=mysql
     - SOLIDUS_BRANCH=v2.2 DB=mysql
     - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,11 @@ group :test do
   end
 end
 
-gem 'pg', '~> 0.21'
-gem 'mysql2', '~> 0.4.10'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
+else
+  gem 'pg', '~> 0.21'
+end
 
 group :development, :test do
   gem "pry-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,11 @@ group :test do
   else
     gem "rails_test_params_backport"
   end
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
 end
 
 gem 'pg', '~> 0.21'

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "database_cleaner", "~> 1.6"
-  s.add_development_dependency "factory_bot", "~> 4.4"
   s.add_development_dependency "ffaker"
   s.add_development_dependency "poltergeist", "~> 1.5"
   s.add_development_dependency "rspec-rails", "~> 3.3"


### PR DESCRIPTION
Load factory_girl for Solidus < 2.5

We need to load a factory_bot version that has factory_girl in it to support Solidus versions < 2.5

Also fixes an issue for people that do not have mysql headers installed (like me). We only need to install the gem, if we also set the `ENV` var that sets the `DB` to `mysql`.