### PR TITLE
Fix to not reuse spree_current_user as `@user`

### DIFF
--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -43,7 +43,7 @@ class Spree::UsersController < Spree::StoreController
     end
 
     def load_object
-      @user ||= spree_current_user
+      @user ||= Spree::User.find_by(id: spree_current_user&.id)
       authorize! params[:action].to_sym, @user
     end
 

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -25,6 +25,8 @@ class Spree::UsersController < Spree::StoreController
 
   def update
     if @user.update_attributes(user_params)
+      spree_current_user.reload
+
       if params[:user][:password].present?
         # this logic needed b/c devise wants to log us out after password changes
         unless Spree::Auth::Config[:signout_after_password_change]

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -4,11 +4,8 @@ RSpec.describe Spree::UsersController, type: :controller do
   let(:user) { create(:user) }
   let(:role) { create(:role) }
 
-  before { allow(controller).to receive(:spree_current_user) { user } }
-
   context '#load_object' do
     it 'redirects to signup path if user is not found' do
-      allow(controller).to receive(:spree_current_user) { nil }
       put :update, params: { user: { email: 'foobar@example.com' } }
       expect(response).to redirect_to spree.login_path
     end
@@ -22,6 +19,8 @@ RSpec.describe Spree::UsersController, type: :controller do
   end
 
   context '#update' do
+    before { sign_in(user) }
+
     context 'when updating own account' do
       it 'performs update' do
         put :update, params: { user: { email: 'mynew@email-address.com' } }

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -22,10 +22,29 @@ RSpec.describe Spree::UsersController, type: :controller do
     before { sign_in(user) }
 
     context 'when updating own account' do
-      it 'performs update' do
-        put :update, params: { user: { email: 'mynew@email-address.com' } }
-        expect(assigns[:user].email).to eq 'mynew@email-address.com'
-        expect(response).to redirect_to spree.account_url(only_path: true)
+
+      context 'when user updated successfuly' do
+        before { put :update, params: { user: { email: 'mynew@email-address.com' } } }
+
+        it 'saves user' do
+          expect(assigns[:user].email).to eq 'mynew@email-address.com'
+        end
+
+        it 'updates spree_current_user' do
+          expect(subject.spree_current_user.email).to eq 'mynew@email-address.com'
+        end
+
+        it 'redirects to account url' do
+          expect(response).to redirect_to spree.account_url(only_path: true)
+        end
+      end
+
+      context 'when user not valid' do
+        before { put :update, params: { user: { email: '' } } }
+
+        it 'does not affect spree_current_user' do
+          expect(subject.spree_current_user.email).to eq user.email
+        end
       end
     end
 


### PR DESCRIPTION
Original implementation `@user ||= spree_current_user` contaminates `spree_current_user` when failed to save `@user`.

It affects customized view like display `spree_current_user.email`.

So I fix to load new `Spree::User` instance.