### PR TITLE
Remove Solidus v2.2 support from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,12 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.2 DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.2 DB=mysql
     - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql


### PR DESCRIPTION
Solidus v2.2 reached its EOL on 2018/11/01, so it doesn't make any sense to keep wasting CI resources on it.