### PR TITLE
Fix typo of frech locale

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -46,5 +46,5 @@ fr:
       not_found: "n'a pas été trouvé"
       not_locked: "n'a pas été bloqué"
       not_saved:
-        one: "1 erreur interdit cette %{ressource} d'être enregistrée :"
+        one: "1 erreur interdit cette %{resource} d'être enregistrée :"
         other: "%{count} erreurs interdisent cette %{resource} d'être enregistrée :"


### PR DESCRIPTION
Whenever `not_saved` key was being called following exception was being raised
```
I18n::MissingInterpolationArgument: missing interpolation argument :ressource in "1 erreur interdit cette %{ressource} d'être enregistrée :" ({:count=>1, :resource=>"utilisateur"} given) (Most recent call first)
```