### PR TITLE
Allow Spree::Admin::UserPasswordsController to be accessed from admin…

### DIFF
--- a/lib/controllers/backend/spree/admin/user_passwords_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_passwords_controller.rb
@@ -8,6 +8,8 @@ class Spree::Admin::UserPasswordsController < Devise::PasswordsController
   helper 'spree/admin/navigation'
   layout 'spree/layouts/admin'
 
+  skip_before_action :require_no_authentication, only: [:create]
+
   # Overridden due to bug in Devise.
   #   respond_with resource, location: new_session_path(resource_name)
   # is generating bad url /session/new.user

--- a/spec/controllers/spree/admin/user_passwords_controller_spec.rb
+++ b/spec/controllers/spree/admin/user_passwords_controller_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Spree::Admin::UserPasswordsController, type: :controller do
+  before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] }
+
+  describe '#create' do
+    it 'responds with success' do
+      post :create, params: { spree_user: { email: 'admin@example.com' } }
+
+      expect(assigns[:spree_user].email).to eq('admin@example.com')
+      expect(response.code).to eq('200')
+    end
+  end
+end


### PR DESCRIPTION
… panel.

Since the Spree::Admin::UserPasswordsController was not being used anywhere within solidus the routes were not working. In order to get it working I needed to add a custom route in routes.rb because the default one was being overridden by the frontend route. Since we are calling this endpoint from the admin, we need to skip the action require_no_authentication because we are already authorizing the admin elsewhere. Without it we receive the error "Filter chain halted as :require_no_authentication rendered or redirected"
#97 Closed due to mess. 