### PR TITLE
Add missing translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,7 @@
 en:
   spree:
     admin_login: Admin Login
+    change_my_password: Change my password
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.


### PR DESCRIPTION
Translation for key `spree.change_my_password` was missing.



<img width="523" alt="schermata 2019-01-11 alle 16 16 47" src="https://user-images.githubusercontent.com/141220/51050136-16b74080-15d0-11e9-85a4-984a127d1878.png">
