### PR TITLE
Add DB index to `reset_password_token` field

### DIFF
--- a/db/migrate/20190125170630_add_reset_password_token_index_to_spree_users.rb
+++ b/db/migrate/20190125170630_add_reset_password_token_index_to_spree_users.rb
@@ -1,0 +1,32 @@
+class AddResetPasswordTokenIndexToSpreeUsers < SolidusSupport::Migration[4.2]
+  # We're not using the standard Rails index name because somebody could have
+  # already added that index to the table. By using a custom name we ensure
+  # that the index can effectively be added and removed via migrations/rollbacks
+  # without having any impact on such installations. The index name is Rails
+  # standard name + "_solidus_auth_devise"; the length is 61 chars which is
+  # still OK for Sqlite, mySQL and Postgres.
+  def custom_index_name
+    'index_spree_users_on_reset_password_token_solidus_auth_devise'
+  end
+
+  def default_index_exists?
+    index_exists?(:spree_users, :reset_password_token)
+  end
+
+  def custom_index_exists?
+    index_exists?(:spree_users, :reset_password_token, name: custom_index_name)
+  end
+
+  def up
+    Spree::User.reset_column_information
+    if Spree::User.column_names.include?('reset_password_token') && !default_index_exists? && !custom_index_exists?
+      add_index :spree_users, :reset_password_token, unique: true, name: custom_index_name
+    end
+  end
+
+  def down
+    if custom_index_exists?
+      remove_index :spree_users, name: custom_index_name
+    end
+  end
+end


### PR DESCRIPTION
Ref #83

This field should have an index in order to ensure uniqueness also at DB level
and to speed up search performances.

The index is added only if it does not exist yet and if the field actually
exists on the DB.

This index is present also in DB migrations generated by Devise gem.