### PR TITLE
Run specs on CircleCi with shared configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,11 @@
 version: 2.1
 
 orbs:
-  solidusio_extensions: solidusio/extensions@0.1.1
+  # Always take the latest version of the orb, this allows us to
+  # run specs against Solidus supported versions only without the need
+  # to change this configuration every time a Solidus version is released
+  # or goes EOL.
+  solidusio_extensions: solidusio/extensions@volatile
 
 jobs:
   run-specs-with-postgres:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,20 @@
 version: 2.1
 
 orbs:
-  solidusio_extensions: solidusio/extensions@0.1.0
+  solidusio_extensions: solidusio/extensions@0.1.1
 
 jobs:
-  build:
+  run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
       - solidusio_extensions/run-tests
+  run-specs-with-mysql:
+    executor: solidusio_extensions/mysql
+    steps:
+      - solidusio_extensions/run-tests
 
+workflows:
+  "Run specs on supported Solidus versions":
+    jobs:
+      - run-specs-with-postgres
+      - run-specs-with-mysql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,3 +22,14 @@ workflows:
     jobs:
       - run-specs-with-postgres
       - run-specs-with-mysql
+  "Weekly run specs against master":
+    triggers:
+      - schedule:
+          cron: "0 0 * * 4" # every Thursday
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - run-specs-with-postgres
+      - run-specs-with-mysql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  solidusio_extensions: solidusio/extensions@0.0.1
+  solidusio_extensions: solidusio/extensions@0.1.0
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2.1
+
+orbs:
+  solidusio_extensions: solidusio/extensions@0.0.1
+
+jobs:
+  build:
+    executor: solidusio_extensions/postgres
+    steps:
+      - solidusio_extensions/run-tests
+


### PR DESCRIPTION
# A new way to run specs on extensions

### The problem

Everytime a new Solidus version is released or goes EOL we need to refresh the CI configuration of **all the extensions** adding or removing a version.  😢 
This is not maintainable with the current core team, and even if we had more development work this is not worth the time, everyone can find better things to do than repeat the same commit on 30 extensions. 


### Requirements

Before presenting the solution I'd like to list our requirements: what we need in order to be able to move from TravisCI to another solution?

- Centralized configuration: we need an external container for the environment configuration where specs run, at least for the supported solidus versions, which is the thing that changes more often
- Ability to change the centralized configuration and have this change reflected into all the extensions that are using it without the need to make a commit for that
- Setup a recurring scheduled build against master: this ensures that if we change something in core that brakes extensions we are notified before releasing Solidus.
- Being able to access build status data via API to populate extensions.solidus.io, which is currently done in this repo: https://github.com/solidusio/extensions.solidus.io

### Proposed Solution

Using [CircleCI Orbs](https://circleci.com/orbs/) we can define a shared configuration that every extension will use at its latest version.

Lately, we experimented a lot with CircleCI Orbs at Nebulab. Our goal there is having a shared CircleCI configuration that we can use on several projects since we use the same tasks. In the past it has been a pain when we needed to update the CircleCI configuration and spread the change on every project that we manage. Working on that I thought that we could use this same approach for this extensions problem and I started experimenting with this PR.

This is the [orb used in this PR](https://circleci.com/orbs/registry/orb/solidusio/extensions). This orb is packed and released at every commit on the master branch of this [solidusio/circleci-orbs-extensions](https://github.com/solidusio/circleci-orbs-extensions) repository.

It basically defines shared tasks that our extensions will use.

With `@volatile`

```yml
orbs:
  solidusio_extensions: solidusio/extensions@volatile
```

we ensure that the extension will always build against the last orb code, which will contain the list of currently supported Solidus versions. The [run-tests](https://github.com/solidusio/circleci-orbs-extensions/blob/f5780da143dc440d34fae3273eb06e4699beba5b/src/commands/run-tests.yml) command is the only file that we need to change on the orb.

The orb also defines two executors ([for mysql and postgres](https://github.com/solidusio/circleci-orbs-extensions/tree/master/src/executors)), which allow us to configure the environment where we want tests to run. 

The configuration of each extension will only have the responsibility to call these shared commands and executors from the orb.

### Extensions Matrix website

I've also created the integration with CircleCI to generate the matrix.  Here's the [Draft PR](https://github.com/solidusio/extensions.solidus.io/pull/26) and the [resulting preview](https://5cf8c7ea2f9d8f7f40f3b401--solidus-extensions.netlify.com/circleci.html).

We can either use it and dismiss the old Travis matrix, or move to a simpler solution (like a simple badge in solidus.io/extensions). 

### What do you think?

Your feedback is important here. We are interested in help improving this solution if any of you have experience with CircleCI and Orbs and also if you have any feedback about if it would be acceptable to dismiss the extensions matrix website, in favor of a simpler solution.

Let me know!

<hr>

TODO:

- [x] create the CircleCI orb configuration so that we can change supported versions in a single point 
- [x] always use latest version of the orb so we can easily propagate the change without any commit
- [x] scheduled weekly builds on all extensions
- [ ] update extensions matrix (move to solidus.io/extensions with a badge?)