### PR TITLE
 Fix migration `20101026184950` `down` method

### DIFF
--- a/db/migrate/20101026184950_rename_columns_for_devise.rb
+++ b/db/migrate/20101026184950_rename_columns_for_devise.rb
@@ -31,7 +31,6 @@ class RenameColumnsForDevise < SolidusSupport::Migration[4.2]
     rename_column :spree_users, :remember_created_at, :remember_token_expires_at
     rename_column :spree_users, :password_salt, :salt
     rename_column :spree_users, :encrypted_password, :crypted_password
-    add_column :spree_users, :unlock_token, :string
     add_column :spree_users, :openid_identifier, :string
   end
 end


### PR DESCRIPTION
When the `up` method of migration `20101026184950` runs after the rollback,
the column `unlock_token` already exists as it's added by the `down` method.

There's no apparent reason to keep adding that column in the `down` method, so
this commit removes it.