### PR TITLE
Allow admins to reset an user's password through the admin panel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,4 @@ group :development, :test do
   gem 'pry-rails', '~> 0.3.9'
 end
 
-gem 'deface', '~> 1.3', require: false
-
 gemspec

--- a/app/overrides/spree/admin/users/edit/_add_reset_password_form.html.erb.deface
+++ b/app/overrides/spree/admin/users/edit/_add_reset_password_form.html.erb.deface
@@ -1,0 +1,20 @@
+<!--
+  insert_before "fieldset#admin_user_edit_api_key"
+  original "904c52ff702412d1dc8d55ff44d87d7f581f6675"
+-->
+
+<% if @user != try_spree_current_user %>
+  <fieldset class="no-border-bottom" data-hook="admin_user_reset_password">
+    <legend><%= t(:'spree.forgot_password') %></legend>
+
+    <%= form_for [:admin, @user], as: :spree_user, url: admin_reset_password_path, method: :post do |f| %>
+      <%= f.hidden_field :email, value: @user.email %>
+
+      <% if can?(:update, @user) %>
+        <div class="align-center">
+          <%= f.submit Spree.user_class.human_attribute_name(:reset_password), class: "button primary" %>
+        </div>
+      <% end %>
+    <% end %>
+  </fieldset>
+<% end %>

--- a/lib/controllers/backend/spree/admin/user_passwords_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_passwords_controller.rb
@@ -25,7 +25,7 @@ class Spree::Admin::UserPasswordsController < Devise::PasswordsController
     set_flash_message(:notice, :send_instructions) if is_navigational_format?
 
     if resource.errors.empty?
-      respond_with resource, location: spree.admin_login_path
+      respond_with resource, location: admin_user_path(resource)
     else
       respond_with_navigational(resource) { render :new }
     end

--- a/lib/solidus_auth_devise.rb
+++ b/lib/solidus_auth_devise.rb
@@ -4,12 +4,4 @@ require "spree_core"
 require "solidus_support"
 require "spree/auth/devise"
 require "spree/authentication_helpers"
-
-if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
-  begin
-    require "deface"
-  rescue LoadError
-    warn "deface is required to run solidus_auth_devise with solidus versions < 2.5. Please add deface to your Gemfile"
-    raise
-  end
-end
+require "deface"

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise-encryptable", "0.2.0"
   s.add_dependency "solidus_core", solidus_version
   s.add_dependency "solidus_support", ">= 0.1.3"
+  s.add_dependency "deface", "~> 1.0"
 
   s.add_development_dependency "capybara", "~> 2.14"
   s.add_development_dependency "capybara-screenshot"

--- a/spec/features/admin/password_reset_spec.rb
+++ b/spec/features/admin/password_reset_spec.rb
@@ -34,4 +34,43 @@ RSpec.feature 'Admin - Reset Password', type: :feature do
   def fill_in_email
     fill_in 'Email', with: 'foobar@example.com'
   end
+
+  context 'password management' do
+    let!(:admin) do
+      create(:admin_user,
+        email: 'admin@example.com',
+        password: 'secret',
+        password_confirmation: 'secret'
+      )
+    end
+
+    let!(:user) do
+      create(:user,
+        email: 'user@example.com',
+        password: 'test123',
+        password_confirmation: 'test123'
+      )
+    end
+
+    before do
+      visit spree.admin_login_path
+      fill_in 'Email', with: admin.email
+      fill_in 'Password', with: admin.password
+      click_button 'Login'
+      visit spree.admin_users_path
+    end
+
+    context 'if currently logged-in admin' do
+      context "clicks on an user's page" do
+        it 'can reset its password' do
+          within("#spree_user_#{user.id}") do
+            click_link user.email
+          end
+
+          click_button 'Reset password'
+          expect(page).to have_content 'You will receive an email with instructions on how to reset your password in a few minutes.'
+        end
+      end
+    end
+  end
 end

--- a/spec/features/admin/password_reset_spec.rb
+++ b/spec/features/admin/password_reset_spec.rb
@@ -68,7 +68,11 @@ RSpec.feature 'Admin - Reset Password', type: :feature do
           end
 
           click_button 'Reset password'
-          expect(page).to have_content 'You will receive an email with instructions on how to reset your password in a few minutes.'
+          expect(page).to have_content(
+            'If an account with that email address exists,
+            you will receive an email with instructions about
+            how to reset your password in a few minutes.'
+          )
         end
       end
     end


### PR DESCRIPTION
This PR aims to serve as a starting point to finally close one of Solidus' oldest issues (solidusio/solidus#438) by adding a "Reset password" button/form admins can use to reset an user's password if necessary. It supeseeds PRs solidusio/solidus#1942 and solidusio/solidus#3151

Said button/form only renders if the user being modified is not the same as the one currently logged-in, as it makes no sense an admin would reset their own password through the admin panel.

This PR also re-introduces Deface (see #114), which might be the most sensible change included in this patch, but it's preferable than entirely overriding a view, as it might be modified in some way by another Solidus extension or the stores themselves.