### PR TITLE
Introduce Rubocop for linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,320 @@
+# Relaxed.Ruby.Style
+
+AllCops:
+  Exclude:
+    - 'spec/dummy/**/*'
+    - 'app/overrides/*'
+    - 'bin/**'
+  TargetRubyVersion: 2.2
+
+# Sometimes I believe this reads better
+# This also causes spacing issues on multi-line fixes
+Style/BracesAroundHashParameters:
+  Enabled: false
+
+# We use class vars and will have to continue doing so for compatability
+Style/ClassVars:
+  Enabled: false
+
+# We need these names for backwards compatability
+Naming/PredicateName:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+
+# This has been used for customization
+Style/MutableConstant:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Performance/Count:
+  Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false
+
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+
+# We can use good judgement here
+Style/RegexpLiteral:
+  Enabled: false
+
+# Unicode comments are useful
+Style/AsciiComments:
+  Enabled: false
+
+Layout/EndAlignment:
+  Enabled: false
+
+Layout/ElseAlignment:
+  Enabled: false
+
+Layout/IndentationWidth:
+  Enabled: false
+
+Layout/AlignParameters:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/IndentArray:
+  Enabled: false
+
+Layout/IndentHash:
+  Enabled: false
+
+Layout/AlignHash:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+# Symbol Arrays are ok and the %i syntax widely unknown
+Style/SymbolArray:
+  Enabled: false
+
+Rails/DynamicFindBy:
+  Whitelist:
+    - find_by_param
+    - find_by_param!
+
+# We use a lot of
+#
+#     expect {
+#       something
+#     }.to { happen }
+#
+# syntax in the specs files.
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - '*/spec/**/*'
+    - 'spec/**/*' # For the benefit of apps that inherit from this config
+
+# We use eval to add common_spree_dependencies into the Gemfiles of each of our gems
+Security/Eval:
+  Exclude:
+    - 'Gemfile'
+    - 'common_spree_dependencies.rb'
+    - '*/Gemfile'
+
+Naming/VariableNumber:
+  Enabled: false
+
+# Write empty methods as you wish.
+Style/EmptyMethod:
+  Enabled: false
+
+# From http://relaxed.ruby.style/
+
+Style/Alias:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylealias
+
+Style/BeginBlock:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylebeginblock
+
+Style/BlockDelimiters:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleblockdelimiters
+
+Style/Documentation:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styledocumentation
+
+Layout/DotPosition:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styledotposition
+
+Style/DoubleNegation:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styledoublenegation
+
+Style/EndBlock:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleendblock
+
+Style/FormatString:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleformatstring
+
+Style/IfUnlessModifier:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleifunlessmodifier
+
+Style/Lambda:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylelambda
+
+Style/ModuleFunction:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylemodulefunction
+
+Style/MultilineBlockChain:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylemultilineblockchain
+
+Style/NegatedIf:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylenegatedif
+
+Style/NegatedWhile:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylenegatedwhile
+
+Style/ParallelAssignment:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleparallelassignment
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylepercentliteraldelimiters
+
+Style/PerlBackrefs:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleperlbackrefs
+
+Style/Semicolon:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesemicolon
+
+Style/SignalException:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesignalexception
+
+Style/SingleLineBlockParams:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesinglelineblockparams
+
+Style/SingleLineMethods:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesinglelinemethods
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylespacebeforeblockbraces
+
+Layout/SpaceInsideParens:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylespaceinsideparens
+
+Style/SpecialGlobalVars:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylespecialglobalvars
+
+Style/StringLiterals:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylestringliterals
+
+Style/SymbolProc:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
+Style/WhileUntilModifier:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylewhileuntilmodifier
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#lintambiguousregexpliteral
+
+Lint/AssignmentInCondition:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#lintassignmentincondition
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+# json.() is idiomatic in jbuilder files
+Style/LambdaCall:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+    - id
+    - to
+    - _
+
+# Rubocop doesn't understand side-effects
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Lint/UselessComparison:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,8 @@ group :test do
   else
     gem "rails_test_params_backport"
   end
-  if branch < "v2.5"
-    gem 'factory_bot', '4.10.0'
-  else
-    gem 'factory_bot', '> 4.10.0'
-  end
+
+  gem 'factory_bot', (branch < 'v2.5' ? '4.10.0' : '> 4.10.0')
 end
 
 if ENV['DB'] == 'mysql'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler::GemHelper.install_tasks
 

--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 module Spree
   class UserMailer < BaseMailer
-    def reset_password_instructions(user, token, *args)
+    def reset_password_instructions(user, token, *_args)
       @store = Spree::Store.default
       @edit_password_reset_url = spree.edit_spree_user_password_url(reset_password_token: token, host: @store.url)
       mail to: user.email, from: from_address(@store), subject: "#{@store.name} #{I18n.t(:subject, scope: [:devise, :mailer, :reset_password_instructions])}"
     end
 
-    def confirmation_instructions(user, token, opts={})
+    def confirmation_instructions(user, token, _opts = {})
       @store = Spree::Store.default
       @confirmation_url = spree.spree_user_confirmation_url(confirmation_token: token, host: @store.url)
       mail to: user.email, from: from_address(@store), subject: "#{@store.name} #{I18n.t(:subject, scope: [:devise, :mailer, :confirmation_instructions])}"

--- a/app/models/spree/auth_configuration.rb
+++ b/app/models/spree/auth_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   class AuthConfiguration < Preferences::Configuration
     preference :registration_step, :boolean, default: true

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   class User < Spree::Base
     include UserMethods
@@ -34,23 +36,24 @@ module Spree
     end
 
     protected
-      def password_required?
-        !persisted? || password.present? || password_confirmation.present?
-      end
+
+    def password_required?
+      !persisted? || password.present? || password_confirmation.present?
+    end
 
     private
 
-      def set_login
-        # for now force login to be same as email, eventually we will make this configurable, etc.
-        self.login ||= self.email if self.email
-      end
+    def set_login
+      # for now force login to be same as email, eventually we will make this configurable, etc.
+      self.login ||= email if email
+    end
 
-      def scramble_email_and_password
-        self.email = SecureRandom.uuid + "@example.net"
-        self.login = self.email
-        self.password = SecureRandom.hex(8)
-        self.password_confirmation = self.password
-        self.save
-      end
+    def scramble_email_and_password
+      self.email = SecureRandom.uuid + "@example.net"
+      self.login = email
+      self.password = SecureRandom.hex(8)
+      self.password_confirmation = password
+      save
+    end
   end
 end

--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -18,10 +18,7 @@ module Spree
 
     before_validation :set_login
 
-    users_table_name = User.table_name
-    roles_table_name = Role.table_name
-
-    scope :admin, -> { includes(:spree_roles).where("#{roles_table_name}.name" => "admin") }
+    scope :admin, -> { includes(:spree_roles).where("#{Role.table_name}.name" => "admin") }
 
     def self.admin_created?
       User.admin.count > 0

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Use this hook to configure devise mailer, warden hooks and so forth. The first
 # four configuration values can also be set straight in your models.
 Devise.setup do |config|
@@ -29,7 +31,7 @@ Devise.setup do |config|
   config.http_authenticatable = true
 
   # Set this to true to use Basic Auth for AJAX requests.  True by default.
-  #config.http_authenticatable_on_xhr = false
+  # config.http_authenticatable_on_xhr = false
 
   # The realm used in Http Basic Authentication
   config.http_authentication_realm = 'Spree Application'

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Merges users orders to their account after sign in and sign up.
-Warden::Manager.after_set_user except: :fetch do |user, auth, opts|
+Warden::Manager.after_set_user except: :fetch do |user, auth, _opts|
   if auth.cookies.signed[:guest_token].present?
     if user.is_a?(Spree::User)
       Spree::Order.incomplete.where(guest_token: auth.cookies.signed[:guest_token], user_id: nil).each do |order|
@@ -9,6 +11,6 @@ Warden::Manager.after_set_user except: :fetch do |user, auth, opts|
   end
 end
 
-Warden::Manager.before_logout do |user, auth, opts|
+Warden::Manager.before_logout do |_user, auth, _opts|
   auth.cookies.delete :guest_token
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 Spree::Core::Engine.routes.draw do
-  if
-    SolidusSupport.frontend_available? &&
-    Spree::Auth::Config.draw_frontend_routes
-
+  if SolidusSupport.frontend_available? && Spree::Auth::Config.draw_frontend_routes
     devise_for(:spree_user, {
       class_name: 'Spree::User',
       controllers: {
@@ -40,10 +37,7 @@ Spree::Core::Engine.routes.draw do
     resource :account, controller: 'users'
   end
 
-  if
-    SolidusSupport.backend_available? &&
-    Spree::Auth::Config.draw_backend_routes
-
+  if SolidusSupport.backend_available? && Spree::Auth::Config.draw_backend_routes
     namespace :admin do
       devise_for(:spree_user, {
         class_name: 'Spree::User',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 Spree::Core::Engine.routes.draw do
-  if (
+  if
     SolidusSupport.frontend_available? &&
     Spree::Auth::Config.draw_frontend_routes
-  )
 
     devise_for(:spree_user, {
       class_name: 'Spree::User',
@@ -39,10 +40,9 @@ Spree::Core::Engine.routes.draw do
     resource :account, controller: 'users'
   end
 
-  if (
+  if
     SolidusSupport.backend_available? &&
     Spree::Auth::Config.draw_backend_routes
-  )
 
     namespace :admin do
       devise_for(:spree_user, {

--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # see last line where we create an admin if there is none, asking for email and password
 def prompt_for_admin_password
   if ENV['ADMIN_PASSWORD']
@@ -31,15 +33,15 @@ def create_admin_user
     email = 'admin@example.com'
   else
     puts 'Create the admin user (press enter for defaults).'
-    #name = prompt_for_admin_name unless name
+    # name = prompt_for_admin_name unless name
     email = prompt_for_admin_email
     password = prompt_for_admin_password
   end
   attributes = {
-    :password => password,
-    :password_confirmation => password,
-    :email => email,
-    :login => email
+    password: password,
+    password_confirmation: password,
+    email: email,
+    login: email
   }
 
   load 'spree/user.rb'

--- a/db/migrate/20101026184949_create_users.rb
+++ b/db/migrate/20101026184949_create_users.rb
@@ -1,17 +1,19 @@
+# frozen_string_literal: true
+
 class CreateUsers < SolidusSupport::Migration[4.2]
   def up
     unless table_exists?("spree_users")
-      create_table "spree_users", :force => true do |t|
-        t.string   "crypted_password",          :limit => 128
-        t.string   "salt",                      :limit => 128
+      create_table "spree_users", force: true do |t|
+        t.string   "crypted_password",          limit: 128
+        t.string   "salt",                      limit: 128
         t.string   "email"
         t.string   "remember_token"
         t.string   "remember_token_expires_at"
         t.string   "persistence_token"
         t.string   "single_access_token"
         t.string   "perishable_token"
-        t.integer  "login_count",                              :default => 0, :null => false
-        t.integer  "failed_login_count",                       :default => 0, :null => false
+        t.integer  "login_count",                              default: 0, null: false
+        t.integer  "failed_login_count",                       default: 0, null: false
         t.datetime "last_request_at"
         t.datetime "current_login_at"
         t.datetime "last_login_at"
@@ -20,8 +22,8 @@ class CreateUsers < SolidusSupport::Migration[4.2]
         t.string   "login"
         t.integer  "ship_address_id"
         t.integer  "bill_address_id"
-        t.datetime "created_at",                                              :null => false
-        t.datetime "updated_at",                                              :null => false
+        t.datetime "created_at",                                              null: false
+        t.datetime "updated_at",                                              null: false
         t.string   "openid_identifier"
       end
     end

--- a/db/migrate/20101026184950_rename_columns_for_devise.rb
+++ b/db/migrate/20101026184950_rename_columns_for_devise.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 class RenameColumnsForDevise < SolidusSupport::Migration[4.2]
   def up
     return if column_exists?(:spree_users, :password_salt)
+
     rename_column :spree_users, :crypted_password, :encrypted_password
     rename_column :spree_users, :salt, :password_salt
     rename_column :spree_users, :remember_token_expires_at, :remember_created_at

--- a/db/migrate/20101214150824_convert_user_remember_field.rb
+++ b/db/migrate/20101214150824_convert_user_remember_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConvertUserRememberField < SolidusSupport::Migration[4.2]
   def up
     remove_column :spree_users, :remember_created_at

--- a/db/migrate/20120203010234_add_reset_password_sent_at_to_spree_users.rb
+++ b/db/migrate/20120203010234_add_reset_password_sent_at_to_spree_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddResetPasswordSentAtToSpreeUsers < SolidusSupport::Migration[4.2]
   def change
     Spree::User.reset_column_information

--- a/db/migrate/20120605211305_make_users_email_index_unique.rb
+++ b/db/migrate/20120605211305_make_users_email_index_unique.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class MakeUsersEmailIndexUnique < SolidusSupport::Migration[4.2]
   def up
-    add_index "spree_users", ["email"], :name => "email_idx_unique", :unique => true
+    add_index "spree_users", ["email"], name: "email_idx_unique", unique: true
   end
 
   def down
-    remove_index "spree_users", :name => "email_idx_unique"
+    remove_index "spree_users", name: "email_idx_unique"
   end
 end

--- a/db/migrate/20140904000425_add_deleted_at_to_users.rb
+++ b/db/migrate/20140904000425_add_deleted_at_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDeletedAtToUsers < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_users, :deleted_at, :datetime

--- a/db/migrate/20141002154641_add_confirmable_to_users.rb
+++ b/db/migrate/20141002154641_add_confirmable_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConfirmableToUsers < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_users, :confirmation_token, :string

--- a/db/migrate/20190125170630_add_reset_password_token_index_to_spree_users.rb
+++ b/db/migrate/20190125170630_add_reset_password_token_index_to_spree_users.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class AddResetPasswordTokenIndexToSpreeUsers < SolidusSupport::Migration[4.2]
   # We're not using the standard Rails index name because somebody could have
-  # already added that index to the table. By using a custom name we ensure
+  #  already added that index to the table. By using a custom name we ensure
   # that the index can effectively be added and removed via migrations/rollbacks
-  # without having any impact on such installations. The index name is Rails
+  #  without having any impact on such installations. The index name is Rails
   # standard name + "_solidus_auth_devise"; the length is 61 chars which is
   # still OK for Sqlite, mySQL and Postgres.
   def custom_index_name

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require_relative 'default/users.rb'

--- a/lib/controllers/backend/spree/admin/admin_controller_decorator.rb
+++ b/lib/controllers/backend/spree/admin/admin_controller_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Spree::Admin::BaseController.class_eval do
   protected
 
@@ -6,6 +8,7 @@ Spree::Admin::BaseController.class_eval do
     if Spree.const_defined?(const_name, false)
       return "Spree::#{const_name}".constantize
     end
+
     nil
   end
 end

--- a/lib/controllers/backend/spree/admin/orders/customer_details_controller_decorator.rb
+++ b/lib/controllers/backend/spree/admin/orders/customer_details_controller_decorator.rb
@@ -1,15 +1,18 @@
+# frozen_string_literal: true
+
 Spree::Admin::Orders::CustomerDetailsController.class_eval do
   before_action :check_authorization
 
   private
-    def check_authorization
-      load_order
-      session[:access_token] ||= params[:token]
 
-      resource = @order
-      action = params[:action].to_sym
-      action = :edit if action == :show # show route renders :edit for this controller
+  def check_authorization
+    load_order
+    session[:access_token] ||= params[:token]
 
-      authorize! action, resource, session[:access_token]
-    end
+    resource = @order
+    action = params[:action].to_sym
+    action = :edit if action == :show # show route renders :edit for this controller
+
+    authorize! action, resource, session[:access_token]
+  end
 end

--- a/lib/controllers/backend/spree/admin/user_passwords_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_passwords_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Spree::Admin::UserPasswordsController < Devise::PasswordsController
   helper 'spree/base'
 
@@ -39,5 +41,4 @@ class Spree::Admin::UserPasswordsController < Devise::PasswordsController
       super
     end
   end
-
 end

--- a/lib/controllers/backend/spree/admin/user_sessions_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_sessions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Spree::Admin::UserSessionsController < Devise::SessionsController
   helper 'spree/base'
 
@@ -19,7 +21,7 @@ class Spree::Admin::UserSessionsController < Devise::SessionsController
         }
         format.js {
           user = resource.record
-          render json: {ship_address: user.ship_address, bill_address: user.bill_address}.to_json
+          render json: { ship_address: user.ship_address, bill_address: user.bill_address }.to_json
         }
       end
     else
@@ -32,12 +34,13 @@ class Spree::Admin::UserSessionsController < Devise::SessionsController
   end
 
   private
-    def accurate_title
-      I18n.t('spree.login')
-    end
 
-    def redirect_back_or_default(default)
-      redirect_to(session["spree_user_return_to"] || default)
-      session["spree_user_return_to"] = nil
-    end
+  def accurate_title
+    I18n.t('spree.login')
+  end
+
+  def redirect_back_or_default(default)
+    redirect_to(session["spree_user_return_to"] || default)
+    session["spree_user_return_to"] = nil
+  end
 end

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Spree::CheckoutController.class_eval do
   prepend_before_action :check_registration,
     except: [:registration, :update_registration]
@@ -22,45 +24,48 @@ Spree::CheckoutController.class_eval do
   end
 
   private
-    def order_params
-      params.
-        fetch(:order, {}).
-        permit(:email)
-    end
 
-    def skip_state_validation?
-      %w(registration update_registration).include?(params[:action])
-    end
+  def order_params
+    params.
+      fetch(:order, {}).
+      permit(:email)
+  end
 
-    def check_authorization
-      authorize!(:edit, current_order, cookies.signed[:guest_token])
-    end
+  def skip_state_validation?
+    %w(registration update_registration).include?(params[:action])
+  end
 
-    # Introduces a registration step whenever the +registration_step+ preference is true.
-    def check_registration
-      return unless registration_required?
-      store_location
-      redirect_to spree.checkout_registration_path
-    end
+  def check_authorization
+    authorize!(:edit, current_order, cookies.signed[:guest_token])
+  end
 
-    def registration_required?
-      Spree::Auth::Config[:registration_step] &&
-        !already_registered?
-    end
+  # Introduces a registration step whenever the +registration_step+ preference is true.
+  def check_registration
+    return unless registration_required?
 
-    def already_registered?
-      spree_current_user || guest_authenticated?
-    end
+    store_location
+    redirect_to spree.checkout_registration_path
+  end
 
-    def guest_authenticated?
-      current_order.try!(:email).present? &&
-        Spree::Config[:allow_guest_checkout]
-    end
+  def registration_required?
+    Spree::Auth::Config[:registration_step] &&
+      !already_registered?
+  end
 
-    # Overrides the equivalent method defined in Spree::Core.  This variation of the method will ensure that users
-    # are redirected to the tokenized order url unless authenticated as a registered user.
-    def completion_route
-      return spree.order_path(@order) if spree_current_user
-      spree.token_order_path(@order, @order.guest_token)
-    end
+  def already_registered?
+    spree_current_user || guest_authenticated?
+  end
+
+  def guest_authenticated?
+    current_order.try!(:email).present? &&
+      Spree::Config[:allow_guest_checkout]
+  end
+
+  # Overrides the equivalent method defined in Spree::Core.  This variation of the method will ensure that users
+  # are redirected to the tokenized order url unless authenticated as a registered user.
+  def completion_route
+    return spree.order_path(@order) if spree_current_user
+
+    spree.token_order_path(@order, @order.guest_token)
+  end
 end

--- a/lib/controllers/frontend/spree/user_confirmations_controller.rb
+++ b/lib/controllers/frontend/spree/user_confirmations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Spree::UserConfirmationsController < Devise::ConfirmationsController
   helper 'spree/base', 'spree/store'
 

--- a/lib/controllers/frontend/spree/user_passwords_controller.rb
+++ b/lib/controllers/frontend/spree/user_passwords_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Spree::UserPasswordsController < Devise::PasswordsController
   helper 'spree/base', 'spree/store'
 

--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Spree::UserRegistrationsController < Devise::RegistrationsController
   helper 'spree/base', 'spree/store'
 
@@ -25,6 +27,7 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
   end
 
   protected
+
   def translation_scope
     'devise.user_registrations'
   end
@@ -34,6 +37,7 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
   end
 
   private
+
   def spree_user_params
     params.require(:spree_user).permit(Spree::PermittedAttributes.user_attributes | [:email])
   end

--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Spree::UserSessionsController < Devise::SessionsController
   helper 'spree/base', 'spree/store'
 

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -48,7 +48,7 @@ class Spree::UsersController < Spree::StoreController
   end
 
   def load_object
-    @user ||= Spree::User.find_by(id: spree_current_user&.id)
+    @user ||= Spree::User.find_by(id: spree_current_user && spree_current_user.id)
     authorize! params[:action].to_sym, @user
   end
 

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Spree::UsersController < Spree::StoreController
   skip_before_action :set_current_order, only: :show, raise: false
   prepend_before_action :load_object, only: [:show, :edit, :update]
@@ -40,20 +42,21 @@ class Spree::UsersController < Spree::StoreController
   end
 
   private
-    def user_params
-      params.require(:user).permit(Spree::PermittedAttributes.user_attributes | [:email])
-    end
 
-    def load_object
-      @user ||= Spree::User.find_by(id: spree_current_user&.id)
-      authorize! params[:action].to_sym, @user
-    end
+  def user_params
+    params.require(:user).permit(Spree::PermittedAttributes.user_attributes | [:email])
+  end
 
-    def authorize_actions
-      authorize! params[:action].to_sym, Spree::User.new
-    end
+  def load_object
+    @user ||= Spree::User.find_by(id: spree_current_user&.id)
+    authorize! params[:action].to_sym, @user
+  end
 
-    def accurate_title
-      I18n.t('spree.my_account')
-    end
+  def authorize_actions
+    authorize! params[:action].to_sym, Spree::User.new
+  end
+
+  def accurate_title
+    I18n.t('spree.my_account')
+  end
 end

--- a/lib/generators/solidus/auth/install/install_generator.rb
+++ b/lib/generators/solidus/auth/install/install_generator.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Solidus
   module Auth
     module Generators
       class InstallGenerator < Rails::Generators::Base
         def self.source_paths
-          paths = self.superclass.source_paths
-          paths << File.expand_path('../templates', __FILE__)
+          paths = superclass.source_paths
+          paths << File.expand_path('templates', __dir__)
           paths.flatten
         end
 

--- a/lib/generators/solidus/auth/install/templates/config/initializers/devise.rb
+++ b/lib/generators/solidus/auth/install/templates/config/initializers/devise.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 Devise.secret_key = SecureRandom.hex(50).inspect

--- a/lib/solidus/auth.rb
+++ b/lib/solidus/auth.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # This file is required by the dummy app's config/environment
 require "solidus_auth_devise"

--- a/lib/solidus_auth_devise.rb
+++ b/lib/solidus_auth_devise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spree_core"
 require "solidus_support"
 require "spree/auth/devise"

--- a/lib/spree/auth/devise.rb
+++ b/lib/spree/auth/devise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spree/core'
 require 'devise'
 require 'devise-encryptable'
@@ -5,7 +7,7 @@ require 'cancan'
 
 module Spree
   module Auth
-    def self.config(&block)
+    def self.config
       yield(Spree::Auth::Config)
     end
   end

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'devise'
 require 'devise-encryptable'
 
@@ -7,7 +9,7 @@ module Spree
       isolate_namespace Spree
       engine_name 'solidus_auth'
 
-      initializer "spree.auth.environment", before: :load_config_initializers do |app|
+      initializer "spree.auth.environment", before: :load_config_initializers do |_app|
         Spree::Auth::Config = Spree::AuthConfiguration.new
       end
 

--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   module AuthenticationHelpers
     def self.included(receiver)

--- a/lib/tasks/auth.rake
+++ b/lib/tasks/auth.rake
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 namespace :spree_auth do
   namespace :admin do
     desc "Create admin username and password"
-    task :create => :environment do
+    task create: :environment do
       require File.join(File.dirname(__FILE__), '..', '..', 'db', 'default', 'users.rb')
       puts "Done!"
     end

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 $:.unshift File.expand_path('lib', __dir__)
 require 'spree/auth/version'
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email        = 'contact@solidus.io'
 
   s.required_ruby_version = ">= 2.1"
-  s.license     = %q{BSD-3}
+  s.license = 'BSD-3'
 
   s.files        = `git ls-files`.split("\n")
   s.test_files   = `git ls-files -- spec/*`.split("\n")
@@ -23,10 +23,10 @@ Gem::Specification.new do |s|
 
   solidus_version = [">= 1.2.0", "< 3"]
 
-  s.add_dependency "solidus_core", solidus_version
-  s.add_dependency "solidus_support", ">= 0.1.3"
   s.add_dependency "devise", '~> 4.1'
   s.add_dependency "devise-encryptable", "0.2.0"
+  s.add_dependency "solidus_core", solidus_version
+  s.add_dependency "solidus_support", ">= 0.1.3"
 
   s.add_development_dependency "capybara", "~> 2.14"
   s.add_development_dependency "capybara-screenshot"

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.author       = 'Solidus Team'
   s.email        = 'contact@solidus.io'
 
-  s.required_ruby_version = ">= 2.1"
+  s.required_ruby_version = ">= 2.2"
   s.license = 'BSD-3'
 
   s.files        = `git ls-files`.split("\n")

--- a/spec/controllers/spree/admin/user_passwords_controller_spec.rb
+++ b/spec/controllers/spree/admin/user_passwords_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Spree::Admin::UserPasswordsController, type: :controller do
   before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] }
 

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe Spree::CheckoutController, type: :controller do
+# frozen_string_literal: true
 
+RSpec.describe Spree::CheckoutController, type: :controller do
   let(:order) { create(:order_with_line_items, email: nil, user: nil, guest_token: token) }
   let(:user)  { build(:user, spree_api_key: 'fake') }
   let(:token) { 'some_token' }

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe Spree::ProductsController, type: :controller do
+# frozen_string_literal: true
 
+RSpec.describe Spree::ProductsController, type: :controller do
   let!(:product) { create(:product, available_on: 1.year.from_now) }
   let!(:user)    { build(:user, spree_api_key: 'fake') }
 

--- a/spec/controllers/spree/user_passwords_controller_spec.rb
+++ b/spec/controllers/spree/user_passwords_controller_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe Spree::UserPasswordsController, type: :controller do
+# frozen_string_literal: true
 
+RSpec.describe Spree::UserPasswordsController, type: :controller do
   let(:token) { 'some_token' }
 
   before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] }
@@ -16,7 +17,7 @@ RSpec.describe Spree::UserPasswordsController, type: :controller do
       it 'flashes an error' do
         get :edit
         expect(flash[:alert]).to include(
-          "You can't access this page without coming from a password reset " +
+          "You can't access this page without coming from a password reset " \
           'email'
         )
       end
@@ -34,7 +35,7 @@ RSpec.describe Spree::UserPasswordsController, type: :controller do
     context 'when updating password with blank password' do
       it 'shows error flash message, sets spree_user with token and re-displays password edit form' do
         put :update, params: { spree_user: { password: '', password_confirmation: '', reset_password_token: token } }
-        expect(assigns(:spree_user).kind_of?(Spree::User)).to eq true
+        expect(assigns(:spree_user).is_a?(Spree::User)).to eq true
         expect(assigns(:spree_user).reset_password_token).to eq token
         expect(flash[:error]).to eq I18n.t(:cannot_be_blank, scope: [:devise, :user_passwords, :spree_user])
         expect(response).to render_template :edit

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe Spree::UserRegistrationsController, type: :controller do
+# frozen_string_literal: true
 
+RSpec.describe Spree::UserRegistrationsController, type: :controller do
   before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] }
 
   context '#create' do

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Spree::UserSessionsController, type: :controller do
   let(:user) { create(:user) }
 

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe Spree::UsersController, type: :controller do
+# frozen_string_literal: true
 
+RSpec.describe Spree::UsersController, type: :controller do
   let(:admin_user) { create(:user) }
   let(:user) { create(:user) }
   let(:role) { create(:role) }
@@ -22,7 +23,6 @@ RSpec.describe Spree::UsersController, type: :controller do
     before { sign_in(user) }
 
     context 'when updating own account' do
-
       context 'when user updated successfuly' do
         before { put :update, params: { user: { email: 'mynew@email-address.com' } } }
 

--- a/spec/factories/confirmed_user.rb
+++ b/spec/factories/confirmed_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :confirmed_user, parent: :user do
     confirmed_at { Time.now }

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Accounts', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Accounts', type: :feature do
   context 'editing' do
     scenario 'can edit an admin user' do
       user = create(:admin_user, email: 'admin@person.com', password: 'password', password_confirmation: 'password')

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Admin orders', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Admin orders', type: :feature do
   background do
     create(:store)
     sign_in_as! create(:admin_user)

--- a/spec/features/admin/password_reset_spec.rb
+++ b/spec/features/admin/password_reset_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Admin - Reset Password', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Admin - Reset Password', type: :feature do
   let!(:store) { create(:store) }
 
   background do

--- a/spec/features/admin/password_reset_spec.rb
+++ b/spec/features/admin/password_reset_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Admin - Reset Password', type: :feature do
   end
 
   scenario 'allows a user to supply an email for the password reset' do
-    user = create(:user, email: 'foobar@example.com', password: 'secret', password_confirmation: 'secret')
+    create(:user, email: 'foobar@example.com', password: 'secret', password_confirmation: 'secret')
     visit spree.admin_login_path
     click_link 'Forgot Password?'
     fill_in 'Email', with: 'foobar@example.com'

--- a/spec/features/admin/products_spec.rb
+++ b/spec/features/admin/products_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Admin products', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Admin products', type: :feature do
   context 'as anonymous user' do
     # Regression test for #1250
     scenario 'redirects to login page when attempting to access product listing' do

--- a/spec/features/admin/sign_in_spec.rb
+++ b/spec/features/admin/sign_in_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Admin - Sign In', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Admin - Sign In', type: :feature do
   background do
     @user = create(:user, email: 'email@person.com')
     visit spree.admin_login_path

--- a/spec/features/admin/sign_out_spec.rb
+++ b/spec/features/admin/sign_out_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Admin - Sign Out', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Admin - Sign Out', type: :feature do
   given!(:user) do
    create :user, email: 'email@person.com'
   end

--- a/spec/features/admin_permissions_spec.rb
+++ b/spec/features/admin_permissions_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Admin Permissions', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Admin Permissions', type: :feature do
   context 'orders' do
     background do
       user = create(:admin_user, email: 'admin@person.com', password: 'password', password_confirmation: 'password')

--- a/spec/features/change_email_spec.rb
+++ b/spec/features/change_email_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Change email', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Change email', type: :feature do
   background do
     Spree::Auth::Config.set(signout_after_password_change: false)
 

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature 'Checkout', :js, type: :feature do
 
     # Regression test for #890
     scenario 'associate an incomplete guest order with user after successful password reset' do
-      user = create(:user, email: 'email@person.com', password: 'password', password_confirmation: 'password')
+      create(:user, email: 'email@person.com', password: 'password', password_confirmation: 'password')
       click_link 'RoR Mug'
       click_button 'Add To Cart'
 

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.feature 'Checkout', :js, type: :feature do
   given!(:store) { create(:store) }
   given!(:country) { create(:country, name: 'United States', states_required: true) }
@@ -61,9 +63,9 @@ RSpec.feature 'Checkout', :js, type: :feature do
       str_addr = 'bill_address'
       select 'United States', from: "order_#{str_addr}_attributes_country_id"
       %w(firstname lastname address1 city zipcode phone).each do |field|
-        fill_in "order_#{str_addr}_attributes_#{field}", with: "#{address.send(field)}"
+        fill_in "order_#{str_addr}_attributes_#{field}", with: address.send(field).to_s
       end
-      select "#{address.state.name}", from: "order_#{str_addr}_attributes_state_id"
+      select address.state.name.to_s, from: "order_#{str_addr}_attributes_state_id"
       check 'order_use_billing'
 
       click_button 'Save and Continue'
@@ -93,9 +95,9 @@ RSpec.feature 'Checkout', :js, type: :feature do
       str_addr = 'bill_address'
       select 'United States', from: "order_#{str_addr}_attributes_country_id"
       %w(firstname lastname address1 city zipcode phone).each do |field|
-        fill_in "order_#{str_addr}_attributes_#{field}", with: "#{address.send(field)}"
+        fill_in "order_#{str_addr}_attributes_#{field}", with: address.send(field).to_s
       end
-      select "#{address.state.name}", from: "order_#{str_addr}_attributes_state_id"
+      select address.state.name.to_s, from: "order_#{str_addr}_attributes_state_id"
       check 'order_use_billing'
 
       click_button 'Save and Continue'
@@ -135,9 +137,9 @@ RSpec.feature 'Checkout', :js, type: :feature do
       str_addr = 'bill_address'
       select 'United States', from: "order_#{str_addr}_attributes_country_id"
       %w(firstname lastname address1 city zipcode phone).each do |field|
-        fill_in "order_#{str_addr}_attributes_#{field}", with: "#{address.send(field)}"
+        fill_in "order_#{str_addr}_attributes_#{field}", with: address.send(field).to_s
       end
-      select "#{address.state.name}", from: "order_#{str_addr}_attributes_state_id"
+      select address.state.name.to_s, from: "order_#{str_addr}_attributes_state_id"
       check 'order_use_billing'
 
       click_button 'Save and Continue'
@@ -164,9 +166,9 @@ RSpec.feature 'Checkout', :js, type: :feature do
       str_addr = 'bill_address'
       select 'United States', from: "order_#{str_addr}_attributes_country_id"
       %w(firstname lastname address1 city zipcode phone).each do |field|
-        fill_in "order_#{str_addr}_attributes_#{field}", with: "#{address.send(field)}"
+        fill_in "order_#{str_addr}_attributes_#{field}", with: address.send(field).to_s
       end
-      select "#{address.state.name}", from: "order_#{str_addr}_attributes_state_id"
+      select address.state.name.to_s, from: "order_#{str_addr}_attributes_state_id"
       check 'order_use_billing'
 
       click_button 'Save and Continue'

--- a/spec/features/confirmation_spec.rb
+++ b/spec/features/confirmation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 feature 'Confirmation' do

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Orders', :js, type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Orders', :js, type: :feature do
   scenario 'allow a user to view their cart at any time' do
     visit spree.cart_path
     expect(page).to have_text 'Your cart is empty'

--- a/spec/features/password_reset_spec.rb
+++ b/spec/features/password_reset_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Reset Password', type: :feature do
   end
 
   scenario 'allow a user to supply an email for the password reset' do
-    user = create(:user, email: 'foobar@example.com', password: 'secret', password_confirmation: 'secret')
+    create(:user, email: 'foobar@example.com', password: 'secret', password_confirmation: 'secret')
     visit spree.login_path
     click_link 'Forgot Password?'
     fill_in 'Email', with: 'foobar@example.com'

--- a/spec/features/password_reset_spec.rb
+++ b/spec/features/password_reset_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Reset Password', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Reset Password', type: :feature do
   let!(:store) { create(:store) }
 
   background do

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Sign In', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Sign In', type: :feature do
   background do
     @user = create(:user, email: 'email@person.com', password: 'secret', password_confirmation: 'secret')
     visit spree.login_path

--- a/spec/features/sign_out_spec.rb
+++ b/spec/features/sign_out_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Sign Out', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Sign Out', type: :feature do
   given!(:user) do
    create(:user,
           email: 'email@person.com',

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -1,5 +1,6 @@
-RSpec.feature 'Sign Up', type: :feature do
+# frozen_string_literal: true
 
+RSpec.feature 'Sign Up', type: :feature do
   context 'with valid data' do
     scenario 'create a new user' do
       visit spree.signup_path

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe Spree::UserMailer, type: :mailer do
+# frozen_string_literal: true
 
+RSpec.describe Spree::UserMailer, type: :mailer do
   let!(:store) { create(:store) }
   let(:user) { create(:user) }
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe Spree::Order, type: :model do
+# frozen_string_literal: true
 
+RSpec.describe Spree::Order, type: :model do
   let(:order) { described_class.new }
 
   context '#associate_user!' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,6 @@
-RSpec.describe Spree::User, type: :model do
+# frozen_string_literal: true
 
+RSpec.describe Spree::User, type: :model do
   before(:all) { Spree::Role.create name: 'admin' }
 
   it '#admin?' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require "simplecov"
 SimpleCov.start "rails"
 
 ENV["RAILS_ENV"] ||= "test"
 
-require File.expand_path("../dummy/config/environment.rb", __FILE__)
+require File.expand_path('dummy/config/environment.rb', __dir__)
 
 require "solidus_support/extension/feature_helper"
 

--- a/spec/support/ability.rb
+++ b/spec/support/ability.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.after do
     Spree::Ability.abilities.delete(AbilityDecorator) if Spree::Ability.abilities.include?(AbilityDecorator)
@@ -8,7 +10,7 @@ if defined? CanCan::Ability
   class AbilityDecorator
     include CanCan::Ability
 
-    def initialize(user)
+    def initialize(_user)
       cannot :manage, Spree::Order
     end
   end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AuthenticationHelpers
   def sign_in_as!(user)
     visit '/login'

--- a/spec/support/confirm_helpers.rb
+++ b/spec/support/confirm_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ConfirmHelpers
   def set_confirmable_option(value)
     if value

--- a/spec/support/email.rb
+++ b/spec/support/email.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before do
     ActionMailer::Base.deliveries.clear

--- a/spec/support/preferences.rb
+++ b/spec/support/preferences.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before do
     Spree::Auth::Config.preference_store = Spree::Auth::Config.default_preferences

--- a/spec/support/spree.rb
+++ b/spec/support/spree.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/controller_requests'


### PR DESCRIPTION
In an effort to improve tooling and to achieve a more consistent development environment, this PR aims to include Rubocop to this gem, as well as fix all the offenses based on the [Rubocop config file](https://github.com/solidusio/solidus/blob/master/.rubocop.yml) that Solidus uses.

**TO-DO**:

* [x] Fix `Lint/Syntax: unexpected token error` raised by [this line](https://github.com/solidusio/solidus_auth_devise/blob/master/lib/controllers/frontend/spree/users_controller.rb#L48)