### PR TITLE
Add gem-release support

### DIFF
--- a/.gem_release.yml
+++ b/.gem_release.yml
@@ -1,0 +1,10 @@
+bump:
+  file: 'lib/spree/auth/version.rb'
+  message: Bump Solidus Auth Devise to %{version}
+  remote: upstream
+  commit: true
+  push: true
+
+tag:
+  push: true
+  remote: upstream

--- a/README.md
+++ b/README.md
@@ -93,3 +93,33 @@ Run the following to automatically build a dummy app if necessary and run the te
 ```shell
 bundle exec rake
 ```
+
+Releasing
+---------
+
+We use [gem-release](https://github.com/svenfuchs/gem-release) to release this
+extension with ease.
+
+Supposing you are on the master branch and you are working on a fork of this
+extension, `upstream` is the main remote and you have write access to it, you
+can simply run:
+
+```
+gem bump --version minor --tag --release
+```
+
+This command will:
+
+- bump the gem version to the next minor (changing the `version.rb` file)
+- commit the change and push it to upstream master
+- create a git tag
+- push the tag to the upstream remote
+- release the new version on RubyGems
+
+Or you can run these commands individually:
+
+```
+gem bump --version minor 
+gem tag
+gem release
+```

--- a/lib/spree/auth/version.rb
+++ b/lib/spree/auth/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Spree
+  module Auth
+    VERSION = '2.1.0'
+  end
+end

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -1,9 +1,12 @@
 # encoding: UTF-8
 
+$:.unshift File.expand_path('lib', __dir__)
+require 'spree/auth/version'
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "solidus_auth_devise"
-  s.version     = "2.1.0"
+  s.version     = Spree::Auth::VERSION
   s.summary     = "Provides authentication and authorization services for use with Solidus by using Devise and CanCan."
   s.description = s.summary
 
@@ -30,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "database_cleaner", "~> 1.6"
   s.add_development_dependency "ffaker"
+  s.add_development_dependency "gem-release", "~> 2.0"
   s.add_development_dependency "poltergeist", "~> 1.5"
   s.add_development_dependency "rspec-rails", "~> 3.3"
   s.add_development_dependency "sass-rails"


### PR DESCRIPTION
This PR introduces [gem-release](https://github.com/svenfuchs/gem-release) to release this extension with ease.

Supposing you are on the master branch and you are working on a fork of this extension, `upstream` is the main remote and you have write access to it, you can simply run:

```
gem bump --version minor --tag --release
```

This command will:

- bump the gem version to the next minor (changing the `version.rb` file)
- commit the change and push it to upstream master
- create a git tag
- push the tag to the upstream remote
- release the new version on RubyGems

Or you can run these commands individually:

```
gem bump --version minor 
gem tag
gem release
```