### PR TITLE
Remove flash errors from admin password recovery

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,8 @@ en:
         no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
         send_instructions: You will receive an email with instructions about how to reset your password in a few minutes.
         updated: Your password was changed successfully. You are now signed in.
+    passwords:
+      send_instructions: If an account with that email address exists, you will receive an email with instructions about how to unlock your account in a few minutes.
     user_registrations:
       destroyed: Bye! Your account was successfully cancelled. We hope to see you again soon.
       inactive_signed_up: 'You have signed up successfully. However, we could not sign you in because your account is %{reason}.'

--- a/lib/controllers/backend/spree/admin/user_passwords_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_passwords_controller.rb
@@ -22,8 +22,9 @@ class Spree::Admin::UserPasswordsController < Devise::PasswordsController
   def create
     self.resource = resource_class.send_reset_password_instructions(params[resource_name])
 
+    set_flash_message(:notice, :send_instructions) if is_navigational_format?
+
     if resource.errors.empty?
-      set_flash_message(:notice, :send_instructions) if is_navigational_format?
       respond_with resource, location: spree.admin_login_path
     else
       respond_with_navigational(resource) { render :new }

--- a/lib/views/backend/spree/admin/user_passwords/new.html.erb
+++ b/lib/views/backend/spree/admin/user_passwords/new.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: 'spree/shared/error_messages', locals: { target: @spree_user } %>
-
 <div id="forgot-password">
   <h6><%= I18n.t('spree.forgot_password') %></h6>
 
@@ -8,7 +6,7 @@
   <%= form_for Spree::User.new, as: :spree_user, url: spree.admin_reset_password_path do |f| %>
     <p>
       <%= f.label :email, I18n.t('spree.email') %><br />
-      <%= f.email_field :email %>
+      <%= f.email_field :email, required: true %>
     </p>
     <p>
       <%= f.submit I18n.t('spree.reset_password'), class: 'button primary' %>

--- a/spec/features/admin/password_reset_spec.rb
+++ b/spec/features/admin/password_reset_spec.rb
@@ -7,19 +7,31 @@ RSpec.feature 'Admin - Reset Password', type: :feature do
     ActionMailer::Base.default_url_options[:host] = 'http://example.com'
   end
 
-  scenario 'allows a user to supply an email for the password reset' do
-    create(:user, email: 'foobar@example.com', password: 'secret', password_confirmation: 'secret')
-    visit spree.admin_login_path
-    click_link 'Forgot Password?'
-    fill_in 'Email', with: 'foobar@example.com'
-    click_button 'Reset my password'
-    expect(page).to have_text 'You will receive an email with instructions'
+  context 'when an account with this email address exists' do
+    let!(:user) { create(:user, email: 'foobar@example.com', password: 'secret', password_confirmation: 'secret') }
+
+    scenario 'allows a user to supply an email for the password reset' do
+      visit spree.admin_login_path
+      click_link 'Forgot Password?'
+      fill_in_email
+      click_button 'Reset my password'
+      expect(page).to have_text 'you will receive an email with instructions'
+    end
   end
 
-  scenario 'shows errors if no email is supplied' do
+  # Revealing that an admin email address is not found allows an attacker to
+  # find admin account email addresses by trying email addresses until this
+  # error is not shown.
+  scenario 'does not reveal email addresses if they are not found' do
     visit spree.admin_login_path
     click_link 'Forgot Password?'
+    fill_in_email
     click_button 'Reset my password'
-    expect(page).to have_text "Email can't be blank"
+    expect(page).to_not have_text "Email not found"
+    expect(page).to have_text 'you will receive an email with instructions'
+  end
+
+  def fill_in_email
+    fill_in 'Email', with: 'foobar@example.com'
   end
 end


### PR DESCRIPTION
It is possible for an attack to deduce admin account email addresses by
injecting email addresses into the password recovery view until the
receive a success message.

The solution in this commit is to remove those flash error messages from
that view entirely. Instead we will flash a generic success message when
the form submits.

This functionality will still exist for non-admin users who may be less
technically savvy and may need help remembering the email address they
used to sign up.

Before: 
![image](https://user-images.githubusercontent.com/11466782/59723270-a7332600-91eb-11e9-80c8-1c2c45ace898.png)

After:
![image](https://user-images.githubusercontent.com/11466782/59723297-c8941200-91eb-11e9-939a-cdffd242e885.png)
