### PR TITLE
Remove flash errors from password recovery

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,7 @@ en:
       spree_user:
         cannot_be_blank: Your password cannot be blank.
         no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-        send_instructions: You will receive an email with instructions about how to reset your password in a few minutes.
+        send_instructions: If an account with that email address exists, you will receive an email with instructions about how to reset your password in a few minutes.
         updated: Your password was changed successfully. You are now signed in.
     passwords:
       send_instructions: If an account with that email address exists, you will receive an email with instructions about how to unlock your account in a few minutes.

--- a/lib/controllers/frontend/spree/user_passwords_controller.rb
+++ b/lib/controllers/frontend/spree/user_passwords_controller.rb
@@ -18,8 +18,9 @@ class Spree::UserPasswordsController < Devise::PasswordsController
   def create
     self.resource = resource_class.send_reset_password_instructions(params[resource_name])
 
+    set_flash_message(:notice, :send_instructions) if is_navigational_format?
+
     if resource.errors.empty?
-      set_flash_message(:notice, :send_instructions) if is_navigational_format?
       respond_with resource, location: spree.login_path
     else
       respond_with_navigational(resource) { render :new }

--- a/lib/views/frontend/spree/user_passwords/new.html.erb
+++ b/lib/views/frontend/spree/user_passwords/new.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: 'spree/shared/error_messages', locals: { target: @spree_user } %>
-
 <div id="forgot-password">
   <h6><%= I18n.t('spree.forgot_password') %></h6>
 
@@ -8,7 +6,7 @@
   <%= form_for Spree::User.new, as: :spree_user, url: spree.reset_password_path do |f| %>
     <p>
       <%= f.label :email, I18n.t('spree.email') %><br />
-      <%= f.email_field :email %>
+      <%= f.email_field :email, required: true %>
     </p>
     <p>
       <%= f.submit I18n.t('spree.reset_password'), class: 'button primary' %>

--- a/spec/features/password_reset_spec.rb
+++ b/spec/features/password_reset_spec.rb
@@ -7,19 +7,31 @@ RSpec.feature 'Reset Password', type: :feature do
     ActionMailer::Base.default_url_options[:host] = 'http://example.com'
   end
 
-  scenario 'allow a user to supply an email for the password reset' do
-    create(:user, email: 'foobar@example.com', password: 'secret', password_confirmation: 'secret')
-    visit spree.login_path
-    click_link 'Forgot Password?'
-    fill_in 'Email', with: 'foobar@example.com'
-    click_button 'Reset my password'
-    expect(page).to have_text 'You will receive an email with instructions'
+  context 'when an account with this email address exists' do
+    let!(:user) { create(:user, email: 'foobar@example.com', password: 'secret', password_confirmation: 'secret') }
+
+    scenario 'allows a user to supply an email for the password reset' do
+      visit spree.login_path
+      click_link 'Forgot Password?'
+      fill_in_email
+      click_button 'Reset my password'
+      expect(page).to have_text 'you will receive an email with instructions'
+    end
   end
 
-  scenario 'shows errors if no email is supplied' do
+  # Test that we are extending the functionality from
+  # https://github.com/solidusio/solidus_auth_devise/pull/155
+  # to the non-admin login
+  scenario 'does not reveal email addresses if they are not found' do
     visit spree.login_path
     click_link 'Forgot Password?'
+    fill_in_email
     click_button 'Reset my password'
-    expect(page).to have_text "Email can't be blank"
+    expect(page).to_not have_text "Email not found"
+    expect(page).to have_text 'you will receive an email with instructions'
+  end
+
+  def fill_in_email
+    fill_in 'Email', with: 'foobar@example.com'
   end
 end


### PR DESCRIPTION
This commit is adding the changes made to the admin password recovery
view in https://github.com/solidusio/solidus_auth_devise/pull/155 to the
non-admin password recovery view.