### PR TITLE
Add rubocop as a development dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,10 +83,10 @@ Layout/ClosingParenthesisIndentation:
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   Enabled: false
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Enabled: false
 
 Layout/AlignHash:

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -2,7 +2,7 @@
 
 Spree::CheckoutController.class_eval do
   prepend_before_action :check_registration,
-    except: [:registration, :update_registration]
+                        except: [:registration, :update_registration]
   prepend_before_action :check_authorization
 
   # This action builds some associations on the order, ex. addresses, which we

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "gem-release", "~> 2.0"
   s.add_development_dependency "poltergeist", "~> 1.5"
   s.add_development_dependency "rspec-rails", "~> 3.3"
+  s.add_development_dependency "rubocop", "0.68"
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "shoulda-matchers", "~> 3.1"
   s.add_development_dependency "simplecov", "~> 0.14"


### PR DESCRIPTION
Rubocop 0.68.0 is the latest version of rubocop that supports Ruby 2.2,
so it's the one we should use.

This commit also makes some minor changes to support using rubocop
0.68.0.