### PR TITLE
Use secret_key_base for Rails 6 compatibility

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -43,7 +43,11 @@ Devise.setup do |config|
   config.encryptor = 'authlogic_sha512'
 
   # Setup a pepper to generate the encrypted password.
-  config.pepper = Rails.configuration.secret_token
+  config.pepper = if Rails.configuration.respond_to?(:secret_token) && Rails.configuration.secret_token.present?
+    Rails.configuration.secret_token
+  else
+    Rails.configuration.secret_key_base
+  end
 
   # ==> Configuration for :confirmable
   # The time you want to give your user to confirm his account. During this time

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -23,6 +23,12 @@ Gem::Specification.new do |s|
 
   solidus_version = [">= 1.2.0", "< 3"]
 
+  s.post_install_message = "
+    NOTE: Rails 6 has removed secret_token in favor of secret_key_base, which was deprecated in
+    Rails 5.2. solidus_auth_devise will keep using secret_token, when present, as the pepper. If
+    secret_token is undefined or not available, secret_key_base will be used instead.
+  ".strip.gsub(/ +/, ' ')
+
   s.add_dependency "devise", '~> 4.1'
   s.add_dependency "devise-encryptable", "0.2.0"
   s.add_dependency "solidus_core", solidus_version


### PR DESCRIPTION
`secret_token` is not available in Rails 6 anymore, it was removed in favor of `secret_key_base`.

With this PR, we adopt `secret_key_base` as the pepper when it's available, ensuring compatibility with Rails 6.  `secret_token` is still used when available, in order to avoid breaking authentication for existing apps.