### PR TITLE
Logout with DELETE verb by default

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -120,6 +120,9 @@ Devise.setup do |config|
   # should add them to the navigational formats lists. Default is [:html]
   config.navigational_formats = [:html, :json, :xml]
 
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not (yet) supported by Devise,
   # you can configure them inside the config.warden block. The example below
@@ -138,7 +141,6 @@ Devise.setup do |config|
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
   config.reset_password_within = 6.hours
-  config.sign_out_via = :get
 
   config.case_insensitive_keys = [:email]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Spree::Core::Engine.routes.draw do
         get '/authorization_failure', to: 'user_sessions#authorization_failure', as: :unauthorized
         get '/login', to: 'user_sessions#new', as: :login
         post '/login', to: 'user_sessions#create', as: :create_new_session
-        get '/logout', to: 'user_sessions#destroy', as: :logout
+        match '/logout', to: 'user_sessions#destroy', as: :logout, via: Devise.sign_out_via
 
         get '/password/recover', to: 'user_passwords#new', as: :recover_password
         post '/password/recover', to: 'user_passwords#create', as: :reset_password

--- a/lib/views/backend/spree/admin/shared/_navigation_footer.html.erb
+++ b/lib/views/backend/spree/admin/shared/_navigation_footer.html.erb
@@ -14,7 +14,7 @@
       <% end %>
     </li>
     <li data-hook="user-logout-link">
-      <%= link_to spree.admin_logout_path do %>
+      <%= link_to spree.admin_logout_path, method: Devise.sign_out_via do %>
         <i class='fa fa-sign-out'></i>
         <%= I18n.t('spree.logout') %>
       <% end %>

--- a/lib/views/frontend/spree/shared/_login_bar_items.html.erb
+++ b/lib/views/frontend/spree/shared/_login_bar_items.html.erb
@@ -1,6 +1,6 @@
 <% if spree_current_user %>
   <li><%= link_to I18n.t('spree.my_account'), spree.account_path %></li>
-  <li><%= link_to I18n.t('spree.logout'), spree.logout_path %></li>
+  <li><%= link_to I18n.t('spree.logout'), spree.logout_path, method: Devise.sign_out_via %></li>
 <% else %>
   <li id="link-to-login"><%= link_to I18n.t('spree.login'), spree.login_path %></li>
 <% end %>

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -112,4 +112,16 @@ RSpec.describe Spree::UserSessionsController, type: :controller do
       end
     end
   end
+
+  context "#destroy" do
+    subject do
+      delete(:destroy)
+    end
+
+    it "redirects to default after signing out" do
+      subject
+      expect(controller.spree_current_user).to be_nil
+      expect(response).to redirect_to spree.root_path
+    end
+  end
 end

--- a/spec/features/admin/sign_out_spec.rb
+++ b/spec/features/admin/sign_out_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Admin - Sign Out', type: :feature do
+RSpec.feature 'Admin - Sign Out', type: :feature, js: true do
   given!(:user) do
    create :user, email: 'email@person.com'
   end

--- a/spec/features/sign_out_spec.rb
+++ b/spec/features/sign_out_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'Sign Out', type: :feature do
+RSpec.feature 'Sign Out', type: :feature, js: true do
   given!(:user) do
    create(:user,
           email: 'email@person.com',
@@ -20,7 +20,7 @@ RSpec.feature 'Sign Out', type: :feature do
   scenario 'allow a signed in user to logout' do
     click_link 'Logout'
     visit spree.root_path
-    expect(page).to have_text 'Login'
-    expect(page).not_to have_text 'Logout'
+    expect(page).to have_text 'LOGIN'
+    expect(page).not_to have_text 'LOGOUT'
   end
 end


### PR DESCRIPTION
[A while ago Devise changed the default HTTP verb used to sign out from `GET` to `DELETE`](https://github.com/plataformatec/devise/pull/4061).

This PR re-aligns this preference default with what is shipped with Devise. It also improves the code to be more dynamic since we were not really supporting changing that preference.

🚨**Can be breaking** 🚨 

Stores that rely on signing out with `GET` verb will need to change the `Devise.sign_out_via` configuration at `config/initializers/devise.rb`:

```ruby
Devise.sign_out_via = :get
```