### PR TITLE
Extension maintenance 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-performance
+  - rubocop-rails
 
 # Relaxed.Ruby.Style
 
@@ -9,6 +10,11 @@ AllCops:
     - 'app/overrides/*'
     - 'bin/**'
   TargetRubyVersion: 2.3
+
+
+Rails/Output:
+  Exclude:
+    - 'db/default/users.rb'
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-performance
+
 # Relaxed.Ruby.Style
 
 AllCops:
@@ -5,7 +8,7 @@ AllCops:
     - 'spec/dummy/**/*'
     - 'app/overrides/*'
     - 'bin/**'
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes
@@ -46,9 +49,6 @@ Style/WordArray:
   Enabled: false
 
 Style/ConditionalAssignment:
-  Enabled: false
-
-Performance/Count:
   Enabled: false
 
 Style/RaiseArgs:

--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -46,7 +46,7 @@ def create_admin_user
 
   load 'spree/user.rb'
 
-  if Spree::User.find_by_email(email)
+  if Spree::User.find_by(email: email)
     puts "\nWARNING: There is already a user with the email: #{email}, so no account changes were made.  If you wish to create an additional admin user, please run rake spree_auth:admin:create again with a different email.\n\n"
   else
     admin = Spree::User.new(attributes)

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -16,7 +16,7 @@ module Spree
     end
 
     def update_registration
-      if params[:order][:email] =~ Devise.email_regexp && current_order.update_attributes(email: params[:order][:email])
+      if params[:order][:email] =~ Devise.email_regexp && current_order.update(email: params[:order][:email])
         redirect_to spree.checkout_path
       else
         flash[:registration_error] = t(:email_is_invalid, scope: [:errors, :messages])
@@ -59,7 +59,7 @@ module Spree
     end
 
     def guest_authenticated?
-      current_order.try!(:email).present? &&
+      current_order&.email.present? &&
         Spree::Config[:allow_guest_checkout]
     end
 

--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -3,7 +3,7 @@
 module Spree
   module CheckoutControllerDecorator
     def self.prepended(base)
-      base.before_action :check_registration, except: [:registration, :update_registration] 
+      base.before_action :check_registration, except: [:registration, :update_registration]
       base.before_action :check_authorization
 
       # This action builds some associations on the order, ex. addresses, which we

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -48,7 +48,7 @@ class Spree::UsersController < Spree::StoreController
   end
 
   def load_object
-    @user ||= Spree::User.find_by(id: spree_current_user && spree_current_user.id)
+    @user ||= Spree::User.find_by(id: spree_current_user&.id)
     authorize! params[:action].to_sym, @user
   end
 

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -26,7 +26,7 @@ class Spree::UsersController < Spree::StoreController
   end
 
   def update
-    if @user.update_attributes(user_params)
+    if @user.update(user_params)
       spree_current_user.reload
 
       if params[:user][:password].present?

--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -19,17 +19,9 @@ module Spree
     end
 
     if SolidusSupport.frontend_available?
-      def spree_login_path
-        spree.login_path
-      end
-
-      def spree_signup_path
-        spree.signup_path
-      end
-
-      def spree_logout_path
-        spree.logout_path
-      end
+      delegate :login_path, :signup_path, :logout_path,
+               to: :spree,
+               prefix: :spree
     end
   end
 end

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.author       = 'Solidus Team'
   s.email        = 'contact@solidus.io'
 
-  s.required_ruby_version = ">= 2.2"
+  s.required_ruby_version = ">= 2.3"
   s.license = 'BSD-3'
 
   s.files        = `git ls-files`.split("\n")
@@ -42,7 +42,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "gem-release", "~> 2.0"
   s.add_development_dependency "poltergeist", "~> 1.5"
   s.add_development_dependency "rspec-rails", "~> 3.3"
-  s.add_development_dependency "rubocop", "0.68"
+  s.add_development_dependency "rubocop", "~> 0.71"
+  s.add_development_dependency "rubocop-performance", "~> 1.4"
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "shoulda-matchers", "~> 3.1"
   s.add_development_dependency "simplecov", "~> 0.14"

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 3.3"
   s.add_development_dependency "rubocop", "~> 0.71"
   s.add_development_dependency "rubocop-performance", "~> 1.4"
+  s.add_development_dependency "rubocop-rails", "~> 2.2"
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "shoulda-matchers", "~> 3.1"
   s.add_development_dependency "simplecov", "~> 0.14"

--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -81,8 +81,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
   context '#update' do
     context 'when in the confirm state' do
       before do
-        order.update_column(:email, 'spree@example.com')
-        order.update_column(:state, 'confirm')
+        order.update(email: 'spree@example.com', state: 'confirm')
 
         # So that the order can transition to complete successfully
         allow(order).to receive(:payment_required?) { false }

--- a/spec/controllers/spree/user_registrations_controller_spec.rb
+++ b/spec/controllers/spree/user_registrations_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Spree::UserRegistrationsController, type: :controller do
         it 'assigns orders with the correct token and no user present' do
           order = create(:order, guest_token: 'ABC', user_id: nil, created_by_id: nil)
           subject
-          user = Spree::User.find_by_email('foobar@example.com')
+          user = Spree::User.find_by(email: 'foobar@example.com')
 
           order.reload
           expect(order.user_id).to eq user.id

--- a/spec/factories/confirmed_user.rb
+++ b/spec/factories/confirmed_user.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :confirmed_user, parent: :user do
-    confirmed_at { Time.now }
-    confirmation_sent_at { Time.now }
+    confirmed_at { Time.zone.now }
+    confirmation_sent_at { Time.zone.now }
     confirmation_token { "12345" }
   end
 end

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Checkout', :js, type: :feature do
 
   background do
     @product = create(:product, name: 'RoR Mug')
-    @product.master.stock_items.first.update_column(:count_on_hand, 1)
+    @product.master.stock_items.first.set_count_on_hand(1)
 
     # Bypass gateway error on checkout | ..or stub a gateway
     Spree::Config[:allow_checkout_on_gateway_error] = true
@@ -177,7 +177,7 @@ RSpec.feature 'Checkout', :js, type: :feature do
       click_button 'Place Order'
 
       expect(page).to have_text 'Your order has been processed successfully'
-      expect(Spree::Order.first.user).to eq Spree::User.find_by_email('email@person.com')
+      expect(Spree::Order.first.user).to eq Spree::User.find_by(email: 'email@person.com')
     end
   end
 end


### PR DESCRIPTION
This PR makes two things:

**Move rubocop performance cops**

This is needed after https://github.com/rubocop-hq/rubocop/issues/5977.

We also need to update the required Ruby version to 2.3 to accommodate the `rubocop`gem update, required by `rubocop-performance`.

**Add rubocop-rails cops**

It provided some useful suggestions which have been fixed within this same PR.