### PR TITLE
Add appropriate classes to admin login button

### DIFF
--- a/lib/views/backend/spree/admin/user_sessions/new.html.erb
+++ b/lib/views/backend/spree/admin/user_sessions/new.html.erb
@@ -22,7 +22,7 @@
         <%= f.label :remember_me, I18n.t('spree.remember_me') %>
       </p>
 
-      <p><%= f.submit I18n.t('spree.login'), class: 'button primary', tabindex: 4 %></p>
+      <p><%= f.submit I18n.t('spree.login'), class: 'btn btn-primary', tabindex: 4 %></p>
     <% end %>
     <%= I18n.t('spree.or') %>
     <%= link_to I18n.t('spree.forgot_password'), spree.admin_recover_password_path %>


### PR DESCRIPTION
**Description**
This adds the new button styles to the admin login button.

Before:
<img width="226" alt="Screen Shot 2019-07-19 at 9 07 58 AM" src="https://user-images.githubusercontent.com/38860342/61541166-c3053400-aa04-11e9-9e07-ae9f8ba2dac5.png">

After:
<img width="242" alt="Screen Shot 2019-07-19 at 9 07 36 AM" src="https://user-images.githubusercontent.com/38860342/61541171-c5678e00-aa04-11e9-9022-3516d8961f9d.png">
