### PR TITLE
Fix CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 sudo: false
 language: ruby
+addons:
+  chrome: stable
+  apt:
+    packages:
+      - chromium-chromedriver
 rvm:
   - 2.3.1
 services:
   - mysql
   - postgresql
+before_install:
+  - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
 env:
   matrix:
     - SOLIDUS_BRANCH=v2.4 DB=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
+services:
+  - mysql
+  - postgresql
 env:
   matrix:
     - SOLIDUS_BRANCH=v2.4 DB=postgres

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -40,10 +40,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency "database_cleaner", "~> 1.6"
   s.add_development_dependency "ffaker"
   s.add_development_dependency "gem-release", "~> 2.0"
-  s.add_development_dependency "poltergeist", "~> 1.5"
   s.add_development_dependency "rspec-rails", "~> 3.3"
   s.add_development_dependency "rubocop", "0.68"
   s.add_development_dependency "sass-rails"
+  s.add_development_dependency "selenium-webdriver", "~> 3.142"
   s.add_development_dependency "shoulda-matchers", "~> 3.1"
   s.add_development_dependency "simplecov", "~> 0.14"
   s.add_development_dependency "solidus_backend", solidus_version


### PR DESCRIPTION
This PR fixes the failing CI builds by adding `selenium-webdriver` as a development dependency (for CircleCI), and specifying DB services / enabling `chromedriver` (for TravisCI)

It also removes `poltergeist` as it's not being used anymore.