### PR TITLE
Stub preferences in specs instead of resetting

### DIFF
--- a/spec/controllers/spree/checkout_controller_spec.rb
+++ b/spec/controllers/spree/checkout_controller_spec.rb
@@ -40,11 +40,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
 
         context 'when guest checkout not allowed' do
           before do
-            Spree::Config.set(allow_guest_checkout: false)
-          end
-
-          after do
-            Spree::Config.set(allow_guest_checkout: true)
+            stub_spree_preferences(allow_guest_checkout: false)
           end
 
           it 'redirects to registration step' do
@@ -57,7 +53,7 @@ RSpec.describe Spree::CheckoutController, type: :controller do
 
     context 'when registration step disabled' do
       before do
-        Spree::Auth::Config.set(registration_step: false)
+        stub_spree_preferences(Spree::Auth::Config, registration_step: false)
       end
 
       context 'when authenticated as registered' do

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Accounts', type: :feature do
     end
 
     scenario 'can edit a new user' do
-      Spree::Auth::Config.set(signout_after_password_change: false)
+      stub_spree_preferences(Spree::Auth::Config, signout_after_password_change: false)
       visit spree.signup_path
 
       fill_in 'Email', with: 'email@person.com'
@@ -36,7 +36,7 @@ RSpec.feature 'Accounts', type: :feature do
     end
 
     scenario 'can edit an existing user account' do
-      Spree::Auth::Config.set(signout_after_password_change: false)
+      stub_spree_preferences(Spree::Auth::Config ,signout_after_password_change: false)
       user = create(:user, email: 'email@person.com', password: 'secret', password_confirmation: 'secret')
       visit spree.login_path
 

--- a/spec/features/change_email_spec.rb
+++ b/spec/features/change_email_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Change email', type: :feature do
   background do
-    Spree::Auth::Config.set(signout_after_password_change: false)
+    stub_spree_preferences(Spree::Auth::Config, signout_after_password_change: false)
 
     user = create(:user)
     visit spree.root_path

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -20,14 +20,14 @@ RSpec.feature 'Checkout', :js, type: :feature do
     @product.master.stock_items.first.set_count_on_hand(1)
 
     # Bypass gateway error on checkout | ..or stub a gateway
-    Spree::Config[:allow_checkout_on_gateway_error] = true
+    stub_spree_preferences(allow_checkout_on_gateway_error: true)
 
     visit spree.root_path
   end
 
   # Regression test for https://github.com/solidusio/solidus/issues/1588
   scenario 'leaving and returning to address step' do
-    Spree::Auth::Config.set(registration_step: true)
+    stub_spree_preferences(Spree::Auth::Config, registration_step: true)
     click_link 'RoR Mug'
     click_button 'Add To Cart'
     within('h1') { expect(page).to have_text 'Shopping Cart' }

--- a/spec/support/confirm_helpers.rb
+++ b/spec/support/confirm_helpers.rb
@@ -4,10 +4,10 @@ module ConfirmHelpers
   def set_confirmable_option(value)
     if value
       Spree::User.devise_modules.push(:confirmable)
-      Spree::Auth::Config.set(confirmable: true)
+      stub_spree_preferences(Spree::Auth::Config, confirmable: true)
     else
       Spree::User.devise_modules.delete(:confirmable)
-      Spree::Auth::Config.set(confirmable: false)
+      stub_spree_preferences(Spree::Auth::Config, confirmable: false)
     end
   end
 end

--- a/spec/support/preferences.rb
+++ b/spec/support/preferences.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.before do
-    Spree::Auth::Config.preference_store = Spree::Auth::Config.default_preferences
+  if SolidusSupport.reset_spree_preferences_deprecated?
+    config.before :suite do
+      Spree::TestingSupport::Preferences.freeze_preferences(Spree::Auth::Config)
+    end
+  else
+    config.before do
+      Spree::Auth::Config.preference_store = Spree::Auth::Config.default_preferences
+    end
   end
 end


### PR DESCRIPTION
Solidus > 2.9 now has a system that allows to stub preferences instead of actually set a value on them and resetting after each spec run. 

This PR makes this extension compatible with that system, still keeping backward compatibility with older Solidus versions.

Also, this is probably something that we should do on every extension.
