### PR TITLE
Do not set Spree.user_class after initialize if already set

### DIFF
--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -14,7 +14,7 @@ module Spree
       end
 
       initializer "solidus_auth_devise.set_user_class", after: :load_config_initializers do
-        Spree.user_class = "Spree::User"
+        Spree.user_class ||= "Spree::User"
       end
 
       config.to_prepare do


### PR DESCRIPTION
Currently, when this class is set with a custom value using an initializer in the host application, it is not having any effect because this line is always overwriting the custom value with the default one.

Ref: #169