### PR TITLE
Fix feature_helper require

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "solidus_support", ">= 0.1.3"
   s.add_dependency "deface", "~> 1.0"
 
-  s.add_development_dependency "capybara", "~> 2.14"
+  s.add_development_dependency "capybara", "~> 3.30"
   s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "database_cleaner", "~> 1.6"

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "shoulda-matchers", "~> 3.1"
   s.add_development_dependency "simplecov", "~> 0.14"
   s.add_development_dependency "solidus_backend", solidus_version
+  s.add_development_dependency "solidus_dev_support", ">= 0.3.0"
   s.add_development_dependency "solidus_frontend", solidus_version
   s.add_development_dependency "sqlite3"
 end

--- a/spec/features/admin/password_reset_spec.rb
+++ b/spec/features/admin/password_reset_spec.rb
@@ -69,9 +69,9 @@ RSpec.feature 'Admin - Reset Password', type: :feature do
 
           click_button 'Reset password'
           expect(page).to have_content(
-            'If an account with that email address exists,
-            you will receive an email with instructions about
-            how to reset your password in a few minutes.'
+            'If an account with that email address exists, '\
+            'you will receive an email with instructions about '\
+            'how to reset your password in a few minutes.'
           )
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,8 @@ ENV["RAILS_ENV"] ||= "test"
 
 require File.expand_path('dummy/config/environment.rb', __dir__)
 
-require "solidus_support/extension/feature_helper"
+require "solidus_dev_support"
+require "solidus_dev_support/rspec/feature_helper"
 
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 


### PR DESCRIPTION
The `feature_helper` file included in `spec_helper` has been moved to a [different gem](https://github.com/solidusio/solidus_support/pull/28).

Including `solidus_dev_support` gives access to this `feature_helper`.

An update to `capybara` was also required to `bundle install`, but with a simple bump and one small test change works correctly.

This should correct the red tests on circleci.