### PR TITLE
Add paranoia dependency explicitly

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "deface", "~> 1.0"
   s.add_dependency "devise", '~> 4.1'
   s.add_dependency "devise-encryptable", "0.2.0"
+  s.add_dependency "paranoia", "~> 2.4"
   s.add_dependency "solidus_core", solidus_version
   s.add_dependency "solidus_support", ">= 0.1.3"
 


### PR DESCRIPTION
Paranoia is being removed from Solidus core in favor of discard. See PR solidusio/solidus#3488 and the related discussions solidusio/solidus#3393 and solidusio/solidus#2354

This adds paranoia dependency explicitly until we'll refactor the [`User`
model](https://github.com/solidusio/solidus_auth_devise/blob/c9293c13998917cf04a0d0b0fd00c7f470fa49ae/app/models/spree/user.rb#L11) here to use discard.