### PR TITLE
Allow to really_destroy! users

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -46,6 +46,8 @@ module Spree
     end
 
     def scramble_email_and_password
+      return true if destroyed?
+
       self.email = SecureRandom.uuid + "@example.net"
       self.login = email
       self.password = SecureRandom.hex(8)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -78,6 +78,15 @@ RSpec.describe Spree::User, type: :model do
     end
   end
 
+  describe '#really_destroy!' do
+    let(:user) { create(:user) }
+
+    it 'removes the record from the database' do
+      user.really_destroy!
+      expect(Spree::User.with_deleted.exists?(id: user.id)).to eql false
+    end
+  end
+
   describe "confirmable" do
     it "is confirmable if the confirmable option is enabled" do
       set_confirmable_option(true)


### PR DESCRIPTION
Fixes #184 

When calling `Spree::User#really_destroy!` the callback `scramble_email_and_password` gets called which tries to save a deleted record resulting in a runtime error.