### PR TITLE
Fill address names combined when needed

### DIFF
--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -60,15 +60,9 @@ RSpec.feature 'Checkout', :js, type: :feature do
       expect(page).to have_text(/Billing Address/i)
       expect(page).to have_text(/Shipping Address/i)
 
-      str_addr = 'bill_address'
-      select 'United States', from: "order_#{str_addr}_attributes_country_id"
-      %w(firstname lastname address1 city zipcode phone).each do |field|
-        fill_in "order_#{str_addr}_attributes_#{field}", with: address.send(field).to_s
-      end
-      select address.state.name.to_s, from: "order_#{str_addr}_attributes_state_id"
-      check 'order_use_billing'
-
+      fill_addresses_fields_with(address)
       click_button 'Save and Continue'
+
       click_button 'Save and Continue'
       click_button 'Save and Continue'
       click_button 'Place Order'
@@ -92,15 +86,9 @@ RSpec.feature 'Checkout', :js, type: :feature do
 
       click_button 'Checkout'
 
-      str_addr = 'bill_address'
-      select 'United States', from: "order_#{str_addr}_attributes_country_id"
-      %w(firstname lastname address1 city zipcode phone).each do |field|
-        fill_in "order_#{str_addr}_attributes_#{field}", with: address.send(field).to_s
-      end
-      select address.state.name.to_s, from: "order_#{str_addr}_attributes_state_id"
-      check 'order_use_billing'
-
+      fill_addresses_fields_with(address)
       click_button 'Save and Continue'
+
       click_button 'Save and Continue'
       click_button 'Save and Continue'
       click_button 'Place Order'
@@ -134,14 +122,7 @@ RSpec.feature 'Checkout', :js, type: :feature do
       click_link 'Cart'
       click_button 'Checkout'
 
-      str_addr = 'bill_address'
-      select 'United States', from: "order_#{str_addr}_attributes_country_id"
-      %w(firstname lastname address1 city zipcode phone).each do |field|
-        fill_in "order_#{str_addr}_attributes_#{field}", with: address.send(field).to_s
-      end
-      select address.state.name.to_s, from: "order_#{str_addr}_attributes_state_id"
-      check 'order_use_billing'
-
+      fill_addresses_fields_with(address)
       click_button 'Save and Continue'
 
       expect(page).not_to have_text 'Email is invalid'
@@ -163,15 +144,9 @@ RSpec.feature 'Checkout', :js, type: :feature do
 
       expect(page).to have_text 'You have signed up successfully.'
 
-      str_addr = 'bill_address'
-      select 'United States', from: "order_#{str_addr}_attributes_country_id"
-      %w(firstname lastname address1 city zipcode phone).each do |field|
-        fill_in "order_#{str_addr}_attributes_#{field}", with: address.send(field).to_s
-      end
-      select address.state.name.to_s, from: "order_#{str_addr}_attributes_state_id"
-      check 'order_use_billing'
-
+      fill_addresses_fields_with(address)
       click_button 'Save and Continue'
+
       click_button 'Save and Continue'
       click_button 'Save and Continue'
       click_button 'Place Order'

--- a/spec/support/features/fill_addresses_fields.rb
+++ b/spec/support/features/fill_addresses_fields.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module FillAddressFields
+  def fill_addresses_fields_with(address)
+    fields = %w[
+      address1
+      city
+      zipcode
+      phone
+    ]
+    fields += if Spree::Config.has_preference?(:use_combined_first_and_last_name_in_address) && Spree::Config.use_combined_first_and_last_name_in_address
+      %w[name]
+    else
+      %w[firstname lastname]
+    end
+
+    fields.each do |field|
+      fill_in "order_bill_address_attributes_#{field}", with: address.send(field).to_s
+    end
+    select 'United States', from: "order_bill_address_attributes_country_id"
+    select address.state.name.to_s, from: "order_bill_address_attributes_state_id"
+
+    check 'order_use_billing'
+  end
+end
+
+RSpec.configure do |config|
+  config.include FillAddressFields, type: :feature
+end


### PR DESCRIPTION
[We introduced a new preference in Solidus core that allows using the combined version of `firstname`/`lastname`](https://github.com/solidusio/solidus/pull/3524).

This PR updates checkout feature specs to reflect this preference.

Once the split version will be deprecated and removed, we can probably also revert this commit and use the combined version only.