### PR TITLE
Fix tests for Devise's :confirmable module

### DIFF
--- a/db/migrate/20200417153503_add_unconfirmed_email_to_spree_users.rb
+++ b/db/migrate/20200417153503_add_unconfirmed_email_to_spree_users.rb
@@ -1,0 +1,7 @@
+class AddUnconfirmedEmailToSpreeUsers < ActiveRecord::Migration[5.2]
+  def change
+    unless column_exists?(:spree_users, :unconfirmed_email)
+      add_column :spree_users, :unconfirmed_email, :string
+    end
+  end
+end

--- a/spec/features/confirmation_spec.rb
+++ b/spec/features/confirmation_spec.rb
@@ -2,9 +2,8 @@
 
 require 'spec_helper'
 
-feature 'Confirmation' do
+RSpec.feature 'Confirmation' do
   before do
-    set_confirmable_option(false)
     allow(Spree::UserMailer).to receive(:confirmation_instructions)
       .and_return(double(deliver: true))
   end
@@ -15,7 +14,7 @@ feature 'Confirmation' do
     ActionMailer::Base.default_url_options[:host] = 'http://example.com'
   end
 
-  scenario 'create a new user', :js do
+  scenario 'create a new user', js: true, confirmable: false do
     visit spree.signup_path
 
     fill_in 'Email', with: 'email@person.com'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,16 +88,12 @@ RSpec.describe Spree::User, type: :model do
   end
 
   describe "confirmable" do
-    it "is confirmable if the confirmable option is enabled" do
-      set_confirmable_option(true)
-      allow(Spree::UserMailer).to receive(:confirmation_instructions).and_return(double(deliver: true))
-      expect(Spree::User.devise_modules).to include(:confirmable)
-      set_confirmable_option(false)
+    it "loads Devise's :confirmable module when :confirmable is true", confirmable: true do
+      expect(Spree::User.ancestors).to include(Devise::Models::Confirmable)
     end
 
-    it "is not confirmable if the confirmable option is disabled" do
-      set_confirmable_option(false)
-      expect(Spree::User.devise_modules).to_not include(:confirmable)
+    it "does not load Devise's :confirmable module when :confirmable is false", confirmable: false do
+      expect(Spree::User.ancestors).not_to include(Devise::Models::Confirmable)
     end
   end
 end


### PR DESCRIPTION
Fixes a fundamental issue with the tests for the `:confirmable` module, that was preventing them from working properly (i.e. the `:confirmable` module was not being loaded at all, and the tests were not testing anything meaningful).

Credits to @vassalloandrea for originally discovering the issue.