### PR TITLE
Redirect back if not authorized

### DIFF
--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -26,26 +26,65 @@ module Spree
         ApplicationController.include Spree::AuthenticationHelpers
       end
 
+      def self.redirect_back_on_unauthorized?
+        return false unless Spree::Config.respond_to?(:redirect_back_on_unauthorized)
+
+        if Spree::Config.redirect_back_on_unauthorized
+          true
+        else
+          Spree::Deprecation.warn <<-WARN.strip_heredoc, caller
+            Having Spree::Config.redirect_back_on_unauthorized set
+            to `false` is deprecated and will not be supported in Solidus 3.0.
+            Please change this configuration to `true` and be sure that your
+            application does not break trying to redirect back when there is
+            an unauthorized access.
+          WARN
+
+          false
+        end
+      end
+
       def self.prepare_backend
         Spree::Admin::BaseController.unauthorized_redirect = -> do
           if try_spree_current_user
             flash[:error] = I18n.t('spree.authorization_failure')
-            redirect_to spree.admin_unauthorized_path
+
+            if Spree::Auth::Engine.redirect_back_on_unauthorized?
+              redirect_back(fallback_location: spree.admin_unauthorized_path)
+            else
+              redirect_to spree.admin_unauthorized_path
+            end
           else
             store_location
-            redirect_to spree.admin_login_path
+
+            if Spree::Auth::Engine.redirect_back_on_unauthorized?
+              redirect_back(fallback_location: spree.admin_login_path)
+            else
+              redirect_to spree.admin_login_path
+            end
           end
         end
       end
+
 
       def self.prepare_frontend
         Spree::BaseController.unauthorized_redirect = -> do
           if try_spree_current_user
             flash[:error] = I18n.t('spree.authorization_failure')
-            redirect_to spree.unauthorized_path
+
+            if Spree::Auth::Engine.redirect_back_on_unauthorized?
+              redirect_back(fallback_location: spree.unauthorized_path)
+            else
+              redirect_to spree.unauthorized_path
+            end
           else
             store_location
-            redirect_to spree.login_path
+
+            if Spree::Auth::Engine.redirect_back_on_unauthorized?
+              redirect_back(fallback_location: spree.login_path)
+            else
+              redirect_to spree.login_path
+            end
           end
         end
       end

--- a/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/spec/controllers/spree/admin/base_controller_spec.rb
@@ -8,19 +8,45 @@ RSpec.describe Spree::Admin::BaseController, type: :controller do
       def index; authorize!(:read, :something); end
     end
 
+    before do
+      stub_spree_preferences(Spree::Config, redirect_back_on_unauthorized: true)
+    end
+
     context "when user is logged in" do
       before { sign_in(create(:user)) }
 
-      it "redirects to unauthorized path" do
-        get :index
-        expect(response).to redirect_to(spree.admin_unauthorized_path)
+      context "when http_referrer is not present" do
+        it "redirects to unauthorized path" do
+          get :index
+          expect(response).to redirect_to(spree.admin_unauthorized_path)
+        end
+      end
+
+      context "when http_referrer is present" do
+        before { request.env['HTTP_REFERER'] = '/redirect' }
+
+        it "redirects back" do
+          get :index
+          expect(response).to redirect_to('/redirect')
+        end
       end
     end
 
     context "when user is not logged in" do
-      it "redirects to login path" do
-        get :index
-        expect(response).to redirect_to(spree.admin_login_path)
+      context "when http_referrer is not present" do
+        it "redirects to login path" do
+          get :index
+          expect(response).to redirect_to(spree.admin_login_path)
+        end
+      end
+
+      context "when http_referrer is present" do
+        before { request.env['HTTP_REFERER'] = '/redirect' }
+
+        it "redirects back" do
+          get :index
+          expect(response).to redirect_to('/redirect')
+        end
       end
     end
   end

--- a/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/spec/controllers/spree/admin/base_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::BaseController, type: :controller do
+  describe '#unauthorized_redirect' do
+    controller(described_class) do
+      def index; authorize!(:read, :something); end
+    end
+
+    context "when user is logged in" do
+      before { sign_in(create(:user)) }
+
+      it "redirects to unauthorized path" do
+        get :index
+        expect(response).to redirect_to(spree.admin_unauthorized_path)
+      end
+    end
+
+    context "when user is not logged in" do
+      it "redirects to login path" do
+        get :index
+        expect(response).to redirect_to(spree.admin_login_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/spree/base_controller_spec.rb
+++ b/spec/controllers/spree/base_controller_spec.rb
@@ -8,19 +8,45 @@ RSpec.describe Spree::BaseController, type: :controller do
       def index; authorize!(:read, :something); end
     end
 
+    before do
+      stub_spree_preferences(Spree::Config, redirect_back_on_unauthorized: true)
+    end
+
     context "when user is logged in" do
       before { sign_in(create(:user)) }
 
-      it "redirects to unauthorized path" do
-        get :index
-        expect(response).to redirect_to(spree.unauthorized_path)
+      context "when http_referrer is not present" do
+        it "redirects to unauthorized path" do
+          get :index
+          expect(response).to redirect_to(spree.unauthorized_path)
+        end
+      end
+
+      context "when http_referrer is present" do
+        before { request.env['HTTP_REFERER'] = '/redirect' }
+
+        it "redirects back" do
+          get :index
+          expect(response).to redirect_to('/redirect')
+        end
       end
     end
 
     context "when user is not logged in" do
-      it "redirects to login path" do
-        get :index
-        expect(response).to redirect_to(spree.login_path)
+      context "when http_referrer is not present" do
+        it "redirects to login path" do
+          get :index
+          expect(response).to redirect_to(spree.login_path)
+        end
+      end
+
+      context "when http_referrer is present" do
+        before { request.env['HTTP_REFERER'] = '/redirect' }
+
+        it "redirects back" do
+          get :index
+          expect(response).to redirect_to('/redirect')
+        end
       end
     end
   end

--- a/spec/controllers/spree/base_controller_spec.rb
+++ b/spec/controllers/spree/base_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::BaseController, type: :controller do
+  describe '#unauthorized_redirect' do
+    controller(described_class) do
+      def index; authorize!(:read, :something); end
+    end
+
+    context "when user is logged in" do
+      before { sign_in(create(:user)) }
+
+      it "redirects to unauthorized path" do
+        get :index
+        expect(response).to redirect_to(spree.unauthorized_path)
+      end
+    end
+
+    context "when user is not logged in" do
+      it "redirects to login path" do
+        get :index
+        expect(response).to redirect_to(spree.login_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a continuation of https://github.com/solidusio/solidus/pull/3118 and tries to redirect back when there's an authentication error.

~After this is merged I think we can safely merge the one in core as well.~

I updated this PR in order to use the preference introduced by the above core PR. Now the new behavior will be only supported on newer versions of Solidus, if that preference will be explicitly changed.