### PR TITLE
Add option to skip migrations

### DIFF
--- a/lib/generators/solidus/auth/install/install_generator.rb
+++ b/lib/generators/solidus/auth/install/install_generator.rb
@@ -5,6 +5,7 @@ module Solidus
     module Generators
       class InstallGenerator < Rails::Generators::Base
         class_option :auto_run_migrations, type: :boolean, default: false
+        class_option :skip_migrations, type: :boolean, default: false
 
         def self.source_paths
           paths = superclass.source_paths
@@ -21,6 +22,8 @@ module Solidus
         end
 
         def run_migrations
+          return if options[:skip_migrations]
+
           run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask('Would you like to run the migrations now? [Y/n]'))
           if run_migrations
             run 'bundle exec rake db:migrate'


### PR DESCRIPTION
In some cases (in particular, the solidus install) it makes sense
to skip the entire migration block. With the current setup, it's
impossible to not run migrations AND not be asked if you want to
run migrations. This allows for a complete skip of the migrations
+ the question asking part, which will smooth out the Solidus installation.

We should also release on rubygems after this PR is accepted, so the change is in effect for Solidus 2.11 - at which point, this will be an issue. Thanks!