### PR TITLE
Use proper name for add_migrations

### DIFF
--- a/lib/generators/solidus/auth/install/install_generator.rb
+++ b/lib/generators/solidus/auth/install/install_generator.rb
@@ -18,7 +18,7 @@ module Solidus
         end
 
         def add_migrations
-          run 'bundle exec rake railties:install:migrations FROM=solidus_auth_devise'
+          run 'bundle exec rake railties:install:migrations FROM=solidus_auth'
         end
 
         def run_migrations


### PR DESCRIPTION
Running the installer on a fresh master (v2.11) Solidus the migrations are not copied in the Rails application.

We need to use the proper engine name in the FROM parameter since the updated installer in Solidus is running the default install generator for solidus_auth_devise if this option is choosen. When running `rails generate solidus:auth:install --skip_migrations=false` it will run the add_migrations script, but this will not install any migrations since this is not the right engine_name. 

also see https://github.com/solidusio/solidus/blob/master/core/lib/generators/solidus/install/install_generator.rb#L127

This commit fixes that.