### PR TITLE
Point to Solidus wiki for gem release

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,45 +98,4 @@ bundle exec rake
 
 ## Releasing a new version
 
-#### 1. Bump gem version and push to RubyGems
-
-We use [gem-release](https://github.com/svenfuchs/gem-release) to release this
-extension with ease.
-
-Supposing you are on the master branch and you are working on a fork of this
-extension, `upstream` is the main remote and you have write access to it, you
-can simply run:
-
-```bash
-gem bump --version minor --tag --release
-```
-
-This command will:
-
-- bump the gem version to the next minor (changing the `version.rb` file)
-- commit the change and push it to upstream master
-- create a git tag
-- push the tag to the upstream remote
-- release the new version on RubyGems
-
-Or you can run these commands individually:
-
-```bash
-gem bump --version minor
-gem tag
-gem release
-```
-
-#### 2. Publish the updated CHANGELOG
-
-After the release is done we can generate the updated CHANGELOG
-using
-[github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator)
-by running the following command:
-
-
-```bash
-bundle exec github_changelog_generator solidusio/solidus_auth_devise --token YOUR_GITHUB_TOKEN
-git commit -am 'Update CHANGELOG'
-git push upstream master
-```
+Please refer to the dedicated [page](https://github.com/solidusio/solidus/wiki/How-to-release-extensions) on Solidus wiki.


### PR DESCRIPTION
In order to centralize the documentation, we should refer to the official extension release page on Solidus wiki.