### PR TITLE
 Replace `I18n.t` with `t` in views

### DIFF
--- a/lib/views/backend/spree/admin/shared/_navigation_footer.html.erb
+++ b/lib/views/backend/spree/admin/shared/_navigation_footer.html.erb
@@ -16,7 +16,7 @@
     <li data-hook="user-logout-link">
       <%= link_to spree.admin_logout_path, method: Devise.sign_out_via do %>
         <i class='fa fa-sign-out'></i>
-        <%= I18n.t('spree.logout') %>
+        <%= t('spree.logout') %>
       <% end %>
     </li>
 
@@ -24,7 +24,7 @@
       <li data-hook="store-frontend-link">
         <%= link_to spree.root_path, target: '_blank' do %>
           <i class='fa fa-external-link'></i>
-          <%= I18n.t('spree.back_to_store') %>
+          <%= t('spree.back_to_store') %>
         <% end %>
       </li>
     <% end %>

--- a/lib/views/backend/spree/admin/user_passwords/edit.html.erb
+++ b/lib/views/backend/spree/admin/user_passwords/edit.html.erb
@@ -1,15 +1,15 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @spree_user } %>
-<h2><%= I18n.t('spree.change_my_password') %></h2>
+<h2><%= t('spree.change_my_password') %></h2>
 
 <%= form_for @spree_user, as: :spree_user, url: spree.update_password_path, method: :put do |f| %>
   <p>
-    <%= f.label :password, I18n.t('spree.password') %><br />
+    <%= f.label :password, t('spree.password') %><br />
     <%= f.password_field :password %><br />
   </p>
   <p>
-    <%= f.label :password_confirmation, I18n.t('spree.confirm_password') %><br />
+    <%= f.label :password_confirmation, t('spree.confirm_password') %><br />
     <%= f.password_field :password_confirmation %><br />
   </p>
   <%= f.hidden_field :reset_password_token %>
-  <%= f.submit I18n.t('spree.update'), class: 'button primary' %>
+  <%= f.submit t('spree.update'), class: 'button primary' %>
 <% end %>

--- a/lib/views/backend/spree/admin/user_passwords/new.html.erb
+++ b/lib/views/backend/spree/admin/user_passwords/new.html.erb
@@ -1,15 +1,15 @@
 <div id="forgot-password">
-  <h6><%= I18n.t('spree.forgot_password') %></h6>
+  <h6><%= t('spree.forgot_password') %></h6>
 
-  <p><%= I18n.t('spree.instructions_to_reset_password') %></p>
+  <p><%= t('spree.instructions_to_reset_password') %></p>
 
   <%= form_for Spree::User.new, as: :spree_user, url: spree.admin_reset_password_path do |f| %>
     <p>
-      <%= f.label :email, I18n.t('spree.email') %><br />
+      <%= f.label :email, t('spree.email') %><br />
       <%= f.email_field :email, required: true %>
     </p>
     <p>
-      <%= f.submit I18n.t('spree.reset_password'), class: 'button primary' %>
+      <%= f.submit t('spree.reset_password'), class: 'button primary' %>
     </p>
   <% end %>
 </div>

--- a/lib/views/backend/spree/admin/user_sessions/authorization_failure.html.erb
+++ b/lib/views/backend/spree/admin/user_sessions/authorization_failure.html.erb
@@ -1,4 +1,4 @@
 <div style="height:50px; padding-top:20px;">
-  <strong><%= I18n.t('spree.authorization_failure') %></strong>
+  <strong><%= t('spree.authorization_failure') %></strong>
 </div>
 <!-- Add your own custom access denied message here if you like -->

--- a/lib/views/backend/spree/admin/user_sessions/new.html.erb
+++ b/lib/views/backend/spree/admin/user_sessions/new.html.erb
@@ -4,28 +4,28 @@
 
 <% @body_id = 'login' %>
 <div id="existing-customer">
-  <h6><%= I18n.t('spree.admin_login') %></h6>
+  <h6><%= t('spree.admin_login') %></h6>
   <div data-hook="login">
     <%= form_for Spree::User.new, as: :spree_user, url: spree.admin_create_new_session_path do |f| %>
       <div id="password-credentials">
         <p>
-          <%= f.label :email, I18n.t('spree.email') %><br />
+          <%= f.label :email, t('spree.email') %><br />
           <%= f.email_field :email, class: 'title', tabindex: 1, autocomplete: 'username' %>
         </p>
         <p>
-          <%= f.label :password, I18n.t('spree.password') %><br />
+          <%= f.label :password, t('spree.password') %><br />
           <%= f.password_field :password, class: 'title', tabindex: 2, autocomplete: 'current-password' %>
         </p>
       </div>
       <p>
         <%= f.check_box :remember_me, tabindex: 3 %>
-        <%= f.label :remember_me, I18n.t('spree.remember_me') %>
+        <%= f.label :remember_me, t('spree.remember_me') %>
       </p>
 
-      <p><%= f.submit I18n.t('spree.login'), class: 'btn btn-primary', tabindex: 4 %></p>
+      <p><%= f.submit t('spree.login'), class: 'btn btn-primary', tabindex: 4 %></p>
     <% end %>
-    <%= I18n.t('spree.or') %>
-    <%= link_to I18n.t('spree.forgot_password'), spree.admin_recover_password_path %>
+    <%= t('spree.or') %>
+    <%= link_to t('spree.forgot_password'), spree.admin_recover_password_path %>
   </div>
 </div>
 <div data-hook="login_extras"></div>

--- a/lib/views/backend/spree/layouts/admin/_login_nav.html.erb
+++ b/lib/views/backend/spree/layouts/admin/_login_nav.html.erb
@@ -1,12 +1,12 @@
 <% if spree_current_user %>
   <ul id="login-nav" class="inline-menu">
-    <li data-hook="user-logged-in-as"><%= I18n.t('spree.logged_in_as') %>: <%= spree_current_user.email %></li>
-    <li data-hook="user-account-link" class='fa fa-user'><%= link_to I18n.t('spree.account'), spree.edit_admin_user_path(spree_current_user) %></li>
-    <li data-hook="user-logout-link" class='fa fa-sign-out'><%= link_to I18n.t('spree.logout'), spree.admin_logout_path %></li>
+    <li data-hook="user-logged-in-as"><%= t('spree.logged_in_as') %>: <%= spree_current_user.email %></li>
+    <li data-hook="user-account-link" class='fa fa-user'><%= link_to t('spree.account'), spree.edit_admin_user_path(spree_current_user) %></li>
+    <li data-hook="user-logout-link" class='fa fa-sign-out'><%= link_to t('spree.logout'), spree.admin_logout_path %></li>
 
     <% if spree.respond_to? :root_path %>
       <li data-hook="store-frontend-link" class='fa fa-external-link'>
-         <%= link_to I18n.t('spree.back_to_store'), spree.root_path, target: '_blank' %>
+         <%= link_to t('spree.back_to_store'), spree.root_path, target: '_blank' %>
       </li>
     <% end %>
   </ul>

--- a/lib/views/frontend/spree/checkout/registration.html.erb
+++ b/lib/views/frontend/spree/checkout/registration.html.erb
@@ -1,21 +1,21 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @user } %>
-<h1><%= I18n.t('spree.registration') %></h1>
+<h1><%= t('spree.registration') %></h1>
 <div id="registration" data-hook>
   <div id="account" class="columns alpha eight">
     <%= render template: 'spree/user_sessions/new' %>
   </div>
   <% if Spree::Config[:allow_guest_checkout] %>
     <div id="guest_checkout" data-hook class="columns omega eight">
-      <h6><%= I18n.t('spree.guest_user_account') %></h6>
+      <h6><%= t('spree.guest_user_account') %></h6>
       <% if flash[:registration_error] %>
         <div class='flash error'><%= flash[:registration_error] %></div>
       <% end %>
       <%= form_for @order, url: update_checkout_registration_path, method: :put, html: { id: 'checkout_form_registration' } do |f| %>
         <p>
-          <%= f.label :email, I18n.t('spree.email') %><br />
+          <%= f.label :email, t('spree.email') %><br />
           <%= f.email_field :email, class: 'title' %>
         </p>
-        <p><%= f.submit I18n.t('spree.continue'), class: 'button primary' %></p>
+        <p><%= f.submit t('spree.continue'), class: 'button primary' %></p>
       <% end %>
     </div>
   <% end %>

--- a/lib/views/frontend/spree/shared/_login.html.erb
+++ b/lib/views/frontend/spree/shared/_login.html.erb
@@ -1,18 +1,18 @@
 <%= form_for Spree::User.new, as: :spree_user, url: spree.create_new_session_path do |f| %>
   <div id="password-credentials">
     <p>
-      <%= f.label :email, I18n.t('spree.email') %><br />
+      <%= f.label :email, t('spree.email') %><br />
       <%= f.email_field :email, class: 'title', tabindex: 1, autofocus: true %>
     </p>
     <p>
-      <%= f.label :password, I18n.t('spree.password') %><br />
+      <%= f.label :password, t('spree.password') %><br />
       <%= f.password_field :password, class: 'title', tabindex: 2 %>
     </p>
   </div>
   <p>
     <%= f.check_box :remember_me, tabindex: 3 %>
-    <%= f.label :remember_me, I18n.t('spree.remember_me') %>
+    <%= f.label :remember_me, t('spree.remember_me') %>
   </p>
 
-  <p><%= f.submit I18n.t('spree.login'), class: 'button primary', tabindex: 4 %></p>
+  <p><%= f.submit t('spree.login'), class: 'button primary', tabindex: 4 %></p>
 <% end %>

--- a/lib/views/frontend/spree/shared/_login_bar_items.html.erb
+++ b/lib/views/frontend/spree/shared/_login_bar_items.html.erb
@@ -1,6 +1,6 @@
 <% if spree_current_user %>
-  <li><%= link_to I18n.t('spree.my_account'), spree.account_path %></li>
-  <li><%= link_to I18n.t('spree.logout'), spree.logout_path, method: Devise.sign_out_via %></li>
+  <li><%= link_to t('spree.my_account'), spree.account_path %></li>
+  <li><%= link_to t('spree.logout'), spree.logout_path, method: Devise.sign_out_via %></li>
 <% else %>
-  <li id="link-to-login"><%= link_to I18n.t('spree.login'), spree.login_path %></li>
+  <li id="link-to-login"><%= link_to t('spree.login'), spree.login_path %></li>
 <% end %>

--- a/lib/views/frontend/spree/shared/_user_form.html.erb
+++ b/lib/views/frontend/spree/shared/_user_form.html.erb
@@ -1,15 +1,15 @@
 <p>
-  <%= f.label :email, I18n.t('spree.email') %><br />
+  <%= f.label :email, t('spree.email') %><br />
   <%= f.email_field :email, class: 'title' %>
 </p>
 <div id="password-credentials">
   <p>
-    <%= f.label :password, I18n.t('spree.password') %><br />
+    <%= f.label :password, t('spree.password') %><br />
     <%= f.password_field :password, class: 'title' %>
   </p>
 
   <p>
-    <%= f.label :password_confirmation, I18n.t('spree.confirm_password') %><br />
+    <%= f.label :password_confirmation, t('spree.confirm_password') %><br />
     <%= f.password_field :password_confirmation, class: 'title' %>
   </p>
 </div>

--- a/lib/views/frontend/spree/user_passwords/edit.html.erb
+++ b/lib/views/frontend/spree/user_passwords/edit.html.erb
@@ -1,17 +1,17 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @spree_user } %>
 <div id="change-password">
-  <h6><%= I18n.t('spree.change_my_password') %></h6>
+  <h6><%= t('spree.change_my_password') %></h6>
 
   <%= form_for @spree_user, as: :spree_user, url: spree.update_password_path, method: :put do |f| %>
     <p>
-      <%= f.label :password, I18n.t('spree.password') %><br />
+      <%= f.label :password, t('spree.password') %><br />
       <%= f.password_field :password %><br />
     </p>
     <p>
-      <%= f.label :password_confirmation, I18n.t('spree.confirm_password') %><br />
+      <%= f.label :password_confirmation, t('spree.confirm_password') %><br />
       <%= f.password_field :password_confirmation %><br />
     </p>
     <%= f.hidden_field :reset_password_token %>
-    <%= f.submit I18n.t('spree.update'), class: 'button primary' %>
+    <%= f.submit t('spree.update'), class: 'button primary' %>
   <% end %>
 </div>

--- a/lib/views/frontend/spree/user_passwords/new.html.erb
+++ b/lib/views/frontend/spree/user_passwords/new.html.erb
@@ -1,15 +1,15 @@
 <div id="forgot-password">
-  <h6><%= I18n.t('spree.forgot_password') %></h6>
+  <h6><%= t('spree.forgot_password') %></h6>
 
-  <p><%= I18n.t('spree.instructions_to_reset_password') %></p>
+  <p><%= t('spree.instructions_to_reset_password') %></p>
 
   <%= form_for Spree::User.new, as: :spree_user, url: spree.reset_password_path do |f| %>
     <p>
-      <%= f.label :email, I18n.t('spree.email') %><br />
+      <%= f.label :email, t('spree.email') %><br />
       <%= f.email_field :email, required: true %>
     </p>
     <p>
-      <%= f.submit I18n.t('spree.reset_password'), class: 'button primary' %>
+      <%= f.submit t('spree.reset_password'), class: 'button primary' %>
     </p>
   <% end %>
 </div>

--- a/lib/views/frontend/spree/user_registrations/new.html.erb
+++ b/lib/views/frontend/spree/user_registrations/new.html.erb
@@ -3,16 +3,16 @@
 <%= render 'spree/shared/error_messages', target: resource %>
 
 <div id="new-customer">
-  <h6><%= I18n.t('spree.new_customer') %></h6>
+  <h6><%= t('spree.new_customer') %></h6>
 
   <div data-hook="signup">
     <%= form_for resource, as: :spree_user, url: spree.registration_path(resource) do |f| %>
       <div data-hook="signup_inside_form">
         <%= render partial: 'spree/shared/user_form', locals: { f: f } %>
-        <p><%= f.submit I18n.t('spree.create'), class: 'button primary' %></p>
+        <p><%= f.submit t('spree.create'), class: 'button primary' %></p>
       </div>
     <% end %>
-    <%= I18n.t('spree.or') %>&nbsp;<%= link_to I18n.t('spree.login_as_existing'), spree.login_path %>
+    <%= t('spree.or') %>&nbsp;<%= link_to t('spree.login_as_existing'), spree.login_path %>
 
   </div>
 

--- a/lib/views/frontend/spree/user_sessions/authorization_failure.html.erb
+++ b/lib/views/frontend/spree/user_sessions/authorization_failure.html.erb
@@ -1,4 +1,4 @@
 <div style="height:50px; padding-top:20px;">
-  <strong><%= I18n.t('spree.authorization_failure') %></strong>
+  <strong><%= t('spree.authorization_failure') %></strong>
 </div>
 <!-- Add your own custom access denied message here if you like -->

--- a/lib/views/frontend/spree/user_sessions/new.html.erb
+++ b/lib/views/frontend/spree/user_sessions/new.html.erb
@@ -4,10 +4,10 @@
 
 <% @body_id = 'login' %>
 <div id="existing-customer">
-  <h6><%= I18n.t('spree.login_as_existing') %></h6>
+  <h6><%= t('spree.login_as_existing') %></h6>
   <div data-hook="login">
     <%= render partial: 'spree/shared/login' %>
-    <%= I18n.t('spree.or') %>&nbsp;<%= link_to I18n.t('spree.create_a_new_account'), spree.signup_path %> | <%= link_to I18n.t('spree.forgot_password'), spree.recover_password_path %>
+    <%= t('spree.or') %>&nbsp;<%= link_to t('spree.create_a_new_account'), spree.signup_path %> | <%= link_to t('spree.forgot_password'), spree.recover_password_path %>
   </div>
 </div>
 <div data-hook="login_extras"></div>

--- a/lib/views/frontend/spree/users/edit.html.erb
+++ b/lib/views/frontend/spree/users/edit.html.erb
@@ -1,13 +1,13 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @user } %>
 
 <div id="edit-account">
-  <h1><%= I18n.t('spree.editing_user') %></h1>
+  <h1><%= t('spree.editing_user') %></h1>
 
   <div data-hook="account_edit">
     <%= form_for Spree::User.new, as: @user, url: spree.user_path(@user), method: :put do |f| %>
       <%= render partial: 'spree/shared/user_form', locals: { f: f } %>
       <p>
-        <%= f.submit I18n.t('spree.update'), class: 'button primary' %>
+        <%= f.submit t('spree.update'), class: 'button primary' %>
       </p>
     <% end %>
   </div>

--- a/lib/views/frontend/spree/users/show.html.erb
+++ b/lib/views/frontend/spree/users/show.html.erb
@@ -2,24 +2,24 @@
 
 <div data-hook="account_summary" class="account-summary">
   <dl id="user-info">
-    <dt><%= I18n.t('spree.email') %></dt>
-    <dd><%= @user.email %> (<%= link_to I18n.t('spree.edit'), spree.edit_account_path %>)</dd>
+    <dt><%= t('spree.email') %></dt>
+    <dd><%= @user.email %> (<%= link_to t('spree.edit'), spree.edit_account_path %>)</dd>
   </dl>
 </div>
 
 <div data-hook="account_my_orders" class="account-my-orders">
 
-  <h3><%= I18n.t('spree.my_orders') %></h3>
+  <h3><%= t('spree.my_orders') %></h3>
   <% if @orders.present? %>
     <table class="order-summary">
       <thead>
       <tr>
-        <th class="order-number"><%= I18n.t(:number, scope: 'activerecord.attributes.spree/order') %></th>
-        <th class="order-date"><%= I18n.t('spree.date') %></th>
-        <th class="order-status"><%= I18n.t('spree.status') %></th>
-        <th class="order-payment-state"><%= I18n.t('spree.payment_state') %></th>
-        <th class="order-shipment-state"><%= I18n.t('spree.shipment_state') %></th>
-        <th class="order-total"><%= I18n.t('spree.total') %></th>
+        <th class="order-number"><%= t(:number, scope: 'activerecord.attributes.spree/order') %></th>
+        <th class="order-date"><%= t('spree.date') %></th>
+        <th class="order-status"><%= t('spree.status') %></th>
+        <th class="order-payment-state"><%= t('spree.payment_state') %></th>
+        <th class="order-shipment-state"><%= t('spree.shipment_state') %></th>
+        <th class="order-total"><%= t('spree.total') %></th>
       </tr>
       </thead>
       <tbody>
@@ -27,16 +27,16 @@
         <tr class="<%= cycle('even', 'odd') %>">
           <td class="order-number"><%= link_to order.number, order_url(order) %></td>
           <td class="order-date"><%= l order.completed_at.to_date %></td>
-          <td class="order-status"><%= I18n.t("spree.order_state.#{order.state}").titleize %></td>
-          <td class="order-payment-state"><%= I18n.t("spree.payment_states.#{order.payment_state}").titleize if order.payment_state %></td>
-          <td class="order-shipment-state"><%= I18n.t("spree.shipment_states.#{order.shipment_state}").titleize if order.shipment_state %></td>
+          <td class="order-status"><%= t("spree.order_state.#{order.state}").titleize %></td>
+          <td class="order-payment-state"><%= t("spree.payment_states.#{order.payment_state}").titleize if order.payment_state %></td>
+          <td class="order-shipment-state"><%= t("spree.shipment_states.#{order.shipment_state}").titleize if order.shipment_state %></td>
           <td class="order-total"><%= order.display_total %></td>
         </tr>
       <% end %>
       </tbody>
     </table>
   <% else %>
-    <p><%= I18n.t('spree.you_have_no_orders_yet') %></p>
+    <p><%= t('spree.you_have_no_orders_yet') %></p>
   <% end %>
   <br />
 


### PR DESCRIPTION
Rails views already include an improved version of `I18n.t` via the module `ActionView::Helpers::TranslationHelper`.