### PR TITLE
Update migrations to support Rails 5.1

### DIFF
--- a/db/migrate/20200417153503_add_unconfirmed_email_to_spree_users.rb
+++ b/db/migrate/20200417153503_add_unconfirmed_email_to_spree_users.rb
@@ -1,4 +1,4 @@
-class AddUnconfirmedEmailToSpreeUsers < ActiveRecord::Migration[5.2]
+class AddUnconfirmedEmailToSpreeUsers < SolidusSupport::Migration[5.1]
   def change
     unless column_exists?(:spree_users, :unconfirmed_email)
       add_column :spree_users, :unconfirmed_email, :string


### PR DESCRIPTION
Until Solidus 3.0.0 we are still supporting Rails 5.1, and so we should make sure the migrations are 5.1 or lower, otherwise Solidus users on Rails 5.1 will see `ArgumentError: Unknown migration version "5.2"; expected one of "4.2", "5.0", "5.1"` when they try to run `rake db:migrate`.