### PR TITLE
Fixes #202 : infinite redirection bug on password change

### DIFF
--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -28,14 +28,17 @@ class Spree::UsersController < Spree::StoreController
   def update
     if @user.update(user_params)
       spree_current_user.reload
+      redirect_url = spree.account_url
 
       if params[:user][:password].present?
         # this logic needed b/c devise wants to log us out after password changes
-        unless Spree::Auth::Config[:signout_after_password_change]
+        if Spree::Auth::Config[:signout_after_password_change]
+          redirect_url = spree.login_url
+        else
           bypass_sign_in(@user)
         end
       end
-      redirect_to spree.account_url, notice: I18n.t('spree.account_updated')
+      redirect_to redirect_url, notice: I18n.t('spree.account_updated')
     else
       render :edit
     end

--- a/spec/controllers/spree/users_controller_spec.rb
+++ b/spec/controllers/spree/users_controller_spec.rb
@@ -46,6 +46,29 @@ RSpec.describe Spree::UsersController, type: :controller do
           expect(subject.spree_current_user.email).to eq user.email
         end
       end
+
+      context 'when updating password' do
+        before do
+          stub_spree_preferences(Spree::Auth::Config, signout_after_password_change: signout_after_change)
+          put :update, params: { user: { password: 'foobar123', password_confirmation: 'foobar123' } }
+        end
+
+        context 'when signout after password change is enabled' do
+          let(:signout_after_change) { true }
+
+          it 'redirects to login url' do
+            expect(response).to redirect_to spree.login_url(only_path: true)
+          end
+        end
+
+        context 'when signout after password change is disabled' do
+          let(:signout_after_change) { false }
+
+          it 'redirects to account url' do
+            expect(response).to redirect_to spree.account_url(only_path: true)
+          end
+        end
+      end
     end
 
     it 'does not update roles' do


### PR DESCRIPTION
**Issue:** Infinite redirection was happening when, config `signout_after_password_change` was set to true, and user tries to change the password.

**Root cause:** When `signout_after_password_change` is enabled, on password change the user gets logged out. But in controller (`Spree::UsersController#update`) we were redirecting the user to account page. This was resulting in unauthorized access and previous URL being same account_edit page, it results in infinite redirection loop. ([Unauthorized access logic here](https://github.com/solidusio/solidus_auth_devise/blob/v2.5.2/lib/spree/auth/engine.rb#L86) tries to redirect to previous page first, which seems correct.)

**Solution:** When user is logged out already we shouldn't redirect it to the account edit page, so changing it to redirect on log_in page.

Fixes #202