### PR TITLE
Allow Solidus 3 version

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  solidus_version = [">= 2.6", "< 3"]
+  solidus_version = [">= 2.6", "< 4"]
 
   s.post_install_message = "
     NOTE: Rails 6 has removed secret_token in favor of secret_key_base, which was deprecated in

--- a/spec/support/features/fill_addresses_fields.rb
+++ b/spec/support/features/fill_addresses_fields.rb
@@ -8,7 +8,7 @@ module FillAddressFields
       zipcode
       phone
     ]
-    fields += if Spree::Config.has_preference?(:use_combined_first_and_last_name_in_address) && Spree::Config.use_combined_first_and_last_name_in_address
+    fields += if SolidusSupport.combined_first_and_last_name_in_address?
       %w[name]
     else
       %w[firstname lastname]


### PR DESCRIPTION
Since master branch of Solidus is tracking `3.0.0.beta` right now we need to make sure that the `solidus_version` here allows using that Solidus version as well.