### PR TITLE
Explicitely require paranoia when needed

### DIFF
--- a/app/models/spree/user.rb
+++ b/app/models/spree/user.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'paranoia'
+
 module Spree
   class User < Spree::Base
     include UserMethods


### PR DESCRIPTION
This is needed with Solidus 3.0 because we dropped paranoia enterely and it's not a core dependency anymore.

It was added as runtime dependency with #183 but the require wasn't here yet.