### PR TITLE
Allow using auth_devise with discard

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |s|
   s.add_dependency "deface", "~> 1.0"
   s.add_dependency "devise", '~> 4.1'
   s.add_dependency "devise-encryptable", "0.2.0"
-  s.add_dependency "paranoia", "~> 2.4"
   s.add_dependency "solidus_core", solidus_version
   s.add_dependency "solidus_support", "~> 0.5"
 


### PR DESCRIPTION
`paranoia` is not required anymore since Solidus 3.0 ships without it.

Who is using older versions of Solidus will see the deprecation as the rest of the paranoia code in core.

This change requires a release with a major bump, since despite the deprecation warning it could be breaking.