### PR TITLE
Stop using try_spree_current_user

### DIFF
--- a/app/overrides/spree/admin/users/edit/_add_reset_password_form.html.erb.deface
+++ b/app/overrides/spree/admin/users/edit/_add_reset_password_form.html.erb.deface
@@ -3,7 +3,7 @@
   original "904c52ff702412d1dc8d55ff44d87d7f581f6675"
 -->
 
-<% if @user != try_spree_current_user %>
+<% if @user != spree_current_user %>
   <fieldset class="no-border-bottom" data-hook="admin_user_reset_password">
     <legend><%= t(:'spree.forgot_password') %></legend>
 

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -48,7 +48,7 @@ module Spree
 
       def self.prepare_backend
         Spree::Admin::BaseController.unauthorized_redirect = -> do
-          if try_spree_current_user
+          if spree_current_user
             flash[:error] = I18n.t('spree.authorization_failure')
 
             if Spree::Auth::Engine.redirect_back_on_unauthorized?
@@ -71,7 +71,7 @@ module Spree
 
       def self.prepare_frontend
         Spree::BaseController.unauthorized_redirect = -> do
-          if try_spree_current_user
+          if spree_current_user
             flash[:error] = I18n.t('spree.authorization_failure')
 
             if Spree::Auth::Engine.redirect_back_on_unauthorized?

--- a/lib/views/backend/spree/admin/shared/_navigation_footer.html.erb
+++ b/lib/views/backend/spree/admin/shared/_navigation_footer.html.erb
@@ -1,15 +1,15 @@
 <% if spree_current_user %>
   <ul id="login-nav" class="admin-login-nav">
     <li data-hook="user-account-link">
-      <% if can?(:admin, try_spree_current_user) %>
-        <%= link_to spree.edit_admin_user_path(try_spree_current_user) do %>
+      <% if can?(:admin, spree_current_user) %>
+        <%= link_to spree.edit_admin_user_path(spree_current_user) do %>
           <i class='fa fa-user'></i>
-          <%= try_spree_current_user.email %>
+          <%= spree_current_user.email %>
         <% end %>
       <% else %>
         <a>
           <i class='fa fa-user'></i>
-          <%= try_spree_current_user.email %>
+          <%= spree_current_user.email %>
         </a>
       <% end %>
     </li>


### PR DESCRIPTION
The current gem is defining `spree_current_user` so we don't need to
be defensive about using it directly.

Related to https://github.com/solidusio/solidus/pull/3923.