### PR TITLE
Specs and setup process housekeeping

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,21 +3,38 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
-require 'rspec/core/rake_task'
+require 'rake/clean'
 require 'spree/testing_support/common_rake'
+ENV['DUMMY_PATH'] = "spec/dummy"
+ENV['LIB_NAME'] = "solidus/auth"
+::CLOBBER.include ENV['DUMMY_PATH']
 
-RSpec::Core::RakeTask.new
-
-task :default do
-  if Dir["spec/dummy"].empty?
-    Rake::Task[:test_app].invoke
-    Dir.chdir("../../")
+namespace :extension do
+  # We need to go back to the gem root since the upstream
+  # extension:test_app changes the working directory to be the dummy app.
+  task :test_app do
+    Rake::Task['extension:test_app'].invoke
+    cd __dir__
   end
-  Rake::Task[:spec].invoke
+
+  directory ENV['DUMMY_PATH'] do
+    Rake::Task['common:test_app'].invoke("Spree::User")
+  end
+
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:specs, [] => FileList[ENV['DUMMY_PATH']]) do |t|
+    # Ref: https://circleci.com/docs/2.0/configuration-reference#store_test_results
+    # Ref: https://github.com/solidusio/circleci-orbs-extensions#test-results-rspec
+    if ENV['TEST_RESULTS_PATH']
+      t.rspec_opts =
+        "--format progress " \
+        "--format RspecJunitFormatter --out #{ENV['TEST_RESULTS_PATH']}"
+    end
+  end
 end
 
-desc 'Generates a dummy app for testing'
-task :test_app do
-  ENV['LIB_NAME'] = 'solidus/auth'
-  Rake::Task['common:test_app'].invoke("Spree::User")
-end
+task default: 'extension:specs'
+
+# DEPRECATED:
+task test_app: 'extension:test_app'
+task spec: 'extension:specs'

--- a/lib/decorators/frontend/controllers/spree/checkout_controller_decorator.rb
+++ b/lib/decorators/frontend/controllers/spree/checkout_controller_decorator.rb
@@ -7,7 +7,7 @@ module Spree
       base.before_action :check_authorization
 
       # This action builds some associations on the order, ex. addresses, which we
-      # don't to build or save here.
+      # don't want to build or save here.
       base.skip_before_action :setup_for_current_state, only: [:registration, :update_registration]
     end
 

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -8,11 +8,7 @@ RSpec.feature 'Orders', :js, type: :feature do
 
   # regression test for spree/spree#1687
   scenario 'merge incomplete orders from different sessions' do
-    skip %{
-      TODO: has been broken for ~2 months as of:
-      https://github.com/spree/spree_auth_devise/commit/3157b47b22c559817d34ec34024587d8aa6136dc
-      I dont think we can decode these sessions anymore since Rails 4 switched to encrypted cookies I believe devise stores session encrypted.
-    }
+    create(:store)
     create(:product, name: 'RoR Mug')
     create(:product, name: 'RoR Shirt')
 

--- a/spec/support/confirm_helpers.rb
+++ b/spec/support/confirm_helpers.rb
@@ -8,6 +8,7 @@ RSpec.configure do |config|
       begin
         example.run
       ensure
+        Spree.send(:remove_const, :User)
         Spree.const_set('User', old_user)
       end
     else


### PR DESCRIPTION
- `bin/setup` was broken when trying to run `rake clobber`
- we had an already initialized constant error in some specs due to a missing constant removal
- the one pending spec in this project has been in that state for "2 months" and 8 years, not anymore