### PR TITLE
Utilize Devise location helpers for redirecting

### DIFF
--- a/lib/controllers/backend/spree/admin/user_sessions_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_sessions_controller.rb
@@ -17,7 +17,7 @@ class Spree::Admin::UserSessionsController < Devise::SessionsController
       respond_to do |format|
         format.html {
           flash[:success] = I18n.t('spree.logged_in_succesfully')
-          redirect_back_or_default(after_sign_in_path_for(spree_current_user))
+          redirect_to stored_spree_user_location_or(after_sign_in_path_for(spree_current_user))
         }
         format.js {
           user = resource.record
@@ -46,10 +46,5 @@ class Spree::Admin::UserSessionsController < Devise::SessionsController
 
   def accurate_title
     I18n.t('spree.login')
-  end
-
-  def redirect_back_or_default(default)
-    redirect_to(session["spree_user_return_to"] || default)
-    session["spree_user_return_to"] = nil
   end
 end

--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -19,7 +19,7 @@ class Spree::UserSessionsController < Devise::SessionsController
       respond_to do |format|
         format.html do
           flash[:success] = I18n.t('spree.logged_in_succesfully')
-          redirect_back_or_default(after_sign_in_path_for(spree_current_user))
+          redirect_to stored_spree_user_location_or(after_sign_in_path_for(spree_current_user))
         end
         format.js { render success_json }
       end
@@ -47,11 +47,6 @@ class Spree::UserSessionsController < Devise::SessionsController
 
   def accurate_title
     I18n.t('spree.login')
-  end
-
-  def redirect_back_or_default(default)
-    redirect_to(session["spree_user_return_to"] || default)
-    session["spree_user_return_to"] = nil
   end
 
   def success_json

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -17,7 +17,7 @@ class Spree::UsersController < Spree::StoreController
         session[:guest_token] = nil
       end
 
-      redirect_back_or_default(root_url)
+      redirect_to stored_spree_user_location_or(root_url)
     else
       render :new
     end

--- a/lib/decorators/frontend/controllers/spree/checkout_controller_decorator.rb
+++ b/lib/decorators/frontend/controllers/spree/checkout_controller_decorator.rb
@@ -45,7 +45,6 @@ module Spree
     def check_registration
       return unless registration_required?
 
-      store_location
       redirect_to spree.checkout_registration_path
     end
 

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -57,7 +57,6 @@ module Spree
               redirect_to spree.admin_unauthorized_path
             end
           else
-            store_location
 
             if Spree::Auth::Engine.redirect_back_on_unauthorized?
               redirect_back(fallback_location: spree.admin_login_path)
@@ -79,7 +78,6 @@ module Spree
               redirect_to spree.unauthorized_path
             end
           else
-            store_location
 
             if Spree::Auth::Engine.redirect_back_on_unauthorized?
               redirect_back(fallback_location: spree.login_path)

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -68,7 +68,6 @@ module Spree
         end
       end
 
-
       def self.prepare_frontend
         Spree::BaseController.unauthorized_redirect = -> do
           if spree_current_user


### PR DESCRIPTION
## Description
Removes #redirect_back_or_default in favor of new simplified methods utilizing Devise helpers `store_location_for` and `stored_location_for`


## Motivation and Context
The method #redirect_back_or_default and the class user_last_url_storer will be deprecated in Solidus [PR #4533](https://github.com/solidusio/solidus/pull/4533) which would break the current build without these changes. Because Devise already provides functionality similar to redirect_back_or_default, the included functions will be utilized by other extensions dependent on solidus_auth_devise

## How Has This Been Tested?
The current test suite covers the changes made in the PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
