### PR TITLE
fix routing and location storage

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,22 +16,38 @@ Spree::Core::Engine.routes.draw do
     resources :users, only: [:edit, :update]
 
     devise_scope :spree_user do
-      # Legacy devise generated routes
-      get 'user/spree_user/sign_in', to: 'user_sessions#new', as: :new_spree_user_session
-      post 'user/spree_user/sign_in', to: 'user_sessions#create', as: :spree_user_session
-      match 'user/spree_user/logout', to: 'user_sessions#destroy', as: :destroy_spree_user_session, via: Devise.sign_out_via
-      get 'user/spree_user/password/new', to: 'user_passwords#new', as: :new_spree_user_password
-      get 'user/spree_user/password/edit', to: 'user_passwords#edit', as: :edit_spree_user_password
-      patch 'user/spree_user/password', to: 'user_passwords#update', as: :spree_user_password
-      put 'user/spree_user/password', to: 'user_passwords#update'
-      post 'user/spree_user/password', to: 'user_passwords#create'
-      get 'user/spree_user/cancel', to: 'user_registrations#cancel', as: :cancel_spree_user_registration
-      get 'user/spree_user/sign_up', to: 'user_registrations#new', as: :new_spree_user_registration
-      get 'user/spree_user/edit', to: 'user_registrations#edit', as: :edit_spree_user_registration
-      patch 'user/spree_user', to: 'user_registrations#update', as: :spree_user_registration
+      # Legacy devise generated paths
+      # These are deprecated but we still want to support the incoming routes,
+      # in order to give existing stores an upgrade path.
+      get 'user/spree_user/sign_in', to: 'user_sessions#new', as: nil
+      post 'user/spree_user/sign_in', to: 'user_sessions#create', as: nil
+      match 'user/spree_user/logout', to: 'user_sessions#destroy', via: Devise.sign_out_via, as: nil
+      get 'user/spree_user/password/new', to: 'user_passwords#new', as: nil
+      get 'user/spree_user/password/edit', to: 'user_passwords#edit', as: nil
+      patch 'user/spree_user/password', to: 'user_passwords#update', as: nil
+      put 'user/spree_user/password', to: 'user_passwords#update', as: nil
+      post 'user/spree_user/password', to: 'user_passwords#create', as: nil
+      get 'user/spree_user/cancel', to: 'user_registrations#cancel', as: nil
+      get 'user/spree_user/sign_up', to: 'user_registrations#new', as: nil
+      get 'user/spree_user/edit', to: 'user_registrations#edit', as: nil
+      patch 'user/spree_user', to: 'user_registrations#update', as: nil
       put 'user/spree_user', to: 'user_registrations#update', as: nil
       delete 'user/spree_user', to: 'user_registrations#destroy', as: nil
       post 'user/spree_user', to: 'user_registrations#create', as: nil
+
+      # Legacy devise generated helpers
+      # These helpers are deprecated but we still want to support them
+      # in order to give existing stores an upgrade path.
+      get '/login', to: 'user_sessions#new', as: :new_spree_user_session
+      post '/login', to: 'user_sessions#create', as: :spree_user_session
+      match '/logout', to: 'user_sessions#destroy', as: :destroy_spree_user_session, via: Devise.sign_out_via
+      get '/password/recover', to: 'user_passwords#new', as: :new_spree_user_password
+      get '/password/change', to: 'user_passwords#edit', as: :edit_spree_user_password
+      patch '/password/change', to: 'user_passwords#update', as: :spree_user_password
+      get '/spree_user/cancel', to: 'user_registrations#cancel', as: :cancel_spree_user_registration
+      get '/signup', to: 'user_registrations#new', as: :new_spree_user_registration
+      get '/spree_user/edit', to: 'user_registrations#edit', as: :edit_spree_user_registration
+      patch '/spree_user', to: 'user_registrations#update', as: :spree_user_registration
 
       # Custom devise routes
       get '/login', to: 'user_sessions#new', as: :login

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,15 +10,30 @@ Spree::Core::Engine.routes.draw do
         passwords: 'spree/user_passwords',
         confirmations: 'spree/user_confirmations'
       },
-      skip: [:unlocks, :omniauth_callbacks],
-      path_names: { sign_out: 'logout' },
-      path_prefix: :user,
-      router_name: :spree
+      skip: :all,
     })
 
     resources :users, only: [:edit, :update]
 
     devise_scope :spree_user do
+      # Legacy devise generated routes
+      get 'user/spree_user/sign_in', to: 'user_sessions#new', as: :new_spree_user_session
+      post 'user/spree_user/sign_in', to: 'user_sessions#create', as: :spree_user_session
+      match 'user/spree_user/logout', to: 'user_sessions#destroy', as: :destroy_spree_user_session, via: Devise.sign_out_via
+      get 'user/spree_user/password/new', to: 'user_passwords#new', as: :new_spree_user_password
+      get 'user/spree_user/password/edit', to: 'user_passwords#edit', as: :edit_spree_user_password
+      patch 'user/spree_user/password', to: 'user_passwords#update', as: :spree_user_password
+      put 'user/spree_user/password', to: 'user_passwords#update'
+      post 'user/spree_user/password', to: 'user_passwords#create'
+      get 'user/spree_user/cancel', to: 'user_registrations#cancel', as: :cancel_spree_user_registration
+      get 'user/spree_user/sign_up', to: 'user_registrations#new', as: :new_spree_user_registration
+      get 'user/spree_user/edit', to: 'user_registrations#edit', as: :edit_spree_user_registration
+      patch 'user/spree_user', to: 'user_registrations#update', as: :spree_user_registration
+      put 'user/spree_user', to: 'user_registrations#update', as: nil
+      delete 'user/spree_user', to: 'user_registrations#destroy', as: nil
+      post 'user/spree_user', to: 'user_registrations#create', as: nil
+
+      # Custom devise routes
       get '/login', to: 'user_sessions#new', as: :login
       post '/login', to: 'user_sessions#create', as: :create_new_session
       match '/logout', to: 'user_sessions#destroy', as: :logout, via: Devise.sign_out_via

--- a/lib/decorators/backend/controllers/spree/admin/base_controller_decorator.rb
+++ b/lib/decorators/backend/controllers/spree/admin/base_controller_decorator.rb
@@ -3,6 +3,12 @@
 module Spree
   module Admin
     module BaseControllerDecorator
+      def self.prepended(base)
+        base.class_eval do
+          before_action :authenticate_spree_user!
+        end
+      end
+
       protected
 
       def model_class

--- a/lib/decorators/frontend/controllers/spree/checkout_controller_decorator.rb
+++ b/lib/decorators/frontend/controllers/spree/checkout_controller_decorator.rb
@@ -45,6 +45,7 @@ module Spree
     def check_registration
       return unless registration_required?
 
+      store_spree_user_location!
       redirect_to spree.checkout_registration_path
     end
 

--- a/lib/decorators/frontend/controllers/spree/users_controller_decorator.rb
+++ b/lib/decorators/frontend/controllers/spree/users_controller_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Spree
+  module UsersControllerDecorator
+    def self.prepended(base)
+      base.class_eval do
+        before_action :authenticate_spree_user!, except: [:new, :create]
+      end
+    end
+
+    ::Spree::UsersController.prepend self
+  end
+end

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -58,13 +58,11 @@ module Spree
             else
               redirect_to spree.admin_unauthorized_path
             end
-          else
+          elsif Spree::Auth::Engine.redirect_back_on_unauthorized?
 
-            if Spree::Auth::Engine.redirect_back_on_unauthorized?
-              redirect_back(fallback_location: spree.admin_login_path)
-            else
-              redirect_to spree.admin_login_path
-            end
+            redirect_back(fallback_location: spree.admin_login_path)
+          else
+            redirect_to spree.admin_login_path
           end
         end
       end
@@ -79,13 +77,11 @@ module Spree
             else
               redirect_to spree.unauthorized_path
             end
-          else
+          elsif Spree::Auth::Engine.redirect_back_on_unauthorized?
 
-            if Spree::Auth::Engine.redirect_back_on_unauthorized?
-              redirect_back(fallback_location: spree.login_path)
-            else
-              redirect_to spree.login_path
-            end
+            redirect_back(fallback_location: spree.login_path)
+          else
+            redirect_to spree.login_path
           end
         end
       end

--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -42,11 +42,11 @@ module Spree
     end
 
     def store_spree_user_location!
-      store_location_for(:spree_current_user, request.fullpath)
+      store_location_for(:spree_user, request.fullpath)
     end
 
     def stored_spree_user_location_or(fallback_location)
-      stored_location_for(:spree_current_user) || fallback_location
+      stored_location_for(:spree_user) || fallback_location
     end
   end
 end

--- a/spec/controllers/spree/user_passwords_controller_spec.rb
+++ b/spec/controllers/spree/user_passwords_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Spree::UserPasswordsController, type: :controller do
       it 'redirects to the new session path' do
         get :edit
         expect(response).to redirect_to(
-          'http://test.host/user/spree_user/sign_in'
+          'http://test.host/login'
         )
       end
 

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature 'Checkout', :js, type: :feature do
       # Need to do this now because the token stored in the DB is the encrypted version
       # The 'plain-text' version is sent in the email and there's one way to get that!
       reset_password_email = ActionMailer::Base.deliveries.first
-      token_url_regex = /\/user\/spree_user\/password\/edit\?reset_password_token=(.*)$/
+      token_url_regex = /\/password\/change\?reset_password_token=(.*)$/
       token = token_url_regex.match(reset_password_email.body.to_s)[1]
 
       visit spree.edit_spree_user_password_path(reset_password_token: token)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Spree::UserMailer, type: :mailer do
 
       context 'body includes' do
         it 'password reset url' do
-          expect(@message.body.raw_source).to include "http://#{store.url}/user/spree_user/password/edit"
+          expect(@message.body.raw_source).to include "http://#{store.url}/password/change"
         end
       end
     end


### PR DESCRIPTION
## Description
Fixes the new store location feature introduced in https://github.com/solidusio/solidus_auth_devise/pull/228

## Motivation and Context
We replaced the method #redirect_back_or_default and the class user_last_url_storer because Devise already provides functionality similar to redirect_back_or_default. After emerging PR#228 We noticed that the redirects were not working as intended and investigated the cause. We found a couple of issues that we missed and needed to be rectified, specifically:

We need to Authenticate the user and not rely on authorization
Utilize `spree_user` instead of `spree_current_user` since that is the scope being utilized
Use implemented custom paths instead of devise helpers for certain routes

## How Has This Been Tested?
The current test suite covers the changes made in the PR - quadrupled checked 👍 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
