### PR TITLE
Revert "Utilize Devise location helpers for redirecting"

### DIFF
--- a/lib/controllers/backend/spree/admin/user_sessions_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_sessions_controller.rb
@@ -17,7 +17,7 @@ class Spree::Admin::UserSessionsController < Devise::SessionsController
       respond_to do |format|
         format.html {
           flash[:success] = I18n.t('spree.logged_in_succesfully')
-          redirect_to stored_spree_user_location_or(after_sign_in_path_for(spree_current_user))
+          redirect_back_or_default(after_sign_in_path_for(spree_current_user))
         }
         format.js {
           user = resource.record
@@ -46,5 +46,10 @@ class Spree::Admin::UserSessionsController < Devise::SessionsController
 
   def accurate_title
     I18n.t('spree.login')
+  end
+
+  def redirect_back_or_default(default)
+    redirect_to(session["spree_user_return_to"] || default)
+    session["spree_user_return_to"] = nil
   end
 end

--- a/lib/controllers/frontend/spree/user_sessions_controller.rb
+++ b/lib/controllers/frontend/spree/user_sessions_controller.rb
@@ -19,7 +19,7 @@ class Spree::UserSessionsController < Devise::SessionsController
       respond_to do |format|
         format.html do
           flash[:success] = I18n.t('spree.logged_in_succesfully')
-          redirect_to stored_spree_user_location_or(after_sign_in_path_for(spree_current_user))
+          redirect_back_or_default(after_sign_in_path_for(spree_current_user))
         end
         format.js { render success_json }
       end
@@ -47,6 +47,11 @@ class Spree::UserSessionsController < Devise::SessionsController
 
   def accurate_title
     I18n.t('spree.login')
+  end
+
+  def redirect_back_or_default(default)
+    redirect_to(session["spree_user_return_to"] || default)
+    session["spree_user_return_to"] = nil
   end
 
   def success_json

--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -17,7 +17,7 @@ class Spree::UsersController < Spree::StoreController
         session[:guest_token] = nil
       end
 
-      redirect_to stored_spree_user_location_or(root_url)
+      redirect_back_or_default(root_url)
     else
       render :new
     end

--- a/lib/decorators/frontend/controllers/spree/checkout_controller_decorator.rb
+++ b/lib/decorators/frontend/controllers/spree/checkout_controller_decorator.rb
@@ -45,6 +45,7 @@ module Spree
     def check_registration
       return unless registration_required?
 
+      store_location
       redirect_to spree.checkout_registration_path
     end
 

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -59,6 +59,7 @@ module Spree
               redirect_to spree.admin_unauthorized_path
             end
           else
+            store_location
 
             if Spree::Auth::Engine.redirect_back_on_unauthorized?
               redirect_back(fallback_location: spree.admin_login_path)
@@ -68,6 +69,7 @@ module Spree
           end
         end
       end
+
 
       def self.prepare_frontend
         Spree::BaseController.unauthorized_redirect = -> do
@@ -80,6 +82,7 @@ module Spree
               redirect_to spree.unauthorized_path
             end
           else
+            store_location
 
             if Spree::Auth::Engine.redirect_back_on_unauthorized?
               redirect_back(fallback_location: spree.login_path)

--- a/lib/spree/authentication_helpers.rb
+++ b/lib/spree/authentication_helpers.rb
@@ -23,30 +23,5 @@ module Spree
                to: :spree,
                prefix: :spree
     end
-
-    private
-
-    def authenticate_spree_user!
-      store_spree_user_location! if storable_spree_user_location?
-
-      super
-    end
-
-    # It's important that the location is NOT stored if:
-    # - The request method is not GET (non idempotent)
-    # - The request is handled by a Devise controller such as Devise::SessionsController as that could cause an
-    #    infinite redirect loop.
-    # - The request is an Ajax request as this can lead to very unexpected behaviour.
-    def storable_spree_user_location?
-      request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
-    end
-
-    def store_spree_user_location!
-      store_location_for(:spree_current_user, request.fullpath)
-    end
-
-    def stored_spree_user_location_or(fallback_location)
-      stored_location_for(:spree_current_user) || fallback_location
-    end
   end
 end


### PR DESCRIPTION
Reverts solidusio/solidus_auth_devise#228

This is causing trouble, and being released in 2.5.5 is preventing admin authentication on new apps using solidus_starter_frontend. The revert will be reinstated on master aiming at the next minor or major release, fixed and  with proper documentation on how to upgrade.

cc @cpfergus1 

For context:
- https://solidusio.slack.com/archives/C0JBKDF35/p1664500519798609?thread_ts=1664264607.635059&cid=C0JBKDF35
- https://github.com/solidusio/solidus_auth_devise/pull/231
- https://github.com/solidusio/solidus_auth_devise/pull/230