### PR TITLE
Fix the standard generator alias and remove interactivity from seeds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ jobs:
       name: solidusio_extensions/postgres
       ruby_version: '3.1'
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-chrome
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
 
@@ -26,8 +26,8 @@ jobs:
       name: solidusio_extensions/mysql
       ruby_version: '3.0'
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-chrome
       - solidusio_extensions/run-tests-solidus-current
       - solidusio_extensions/store-test-results
 
@@ -36,15 +36,14 @@ jobs:
       name: solidusio_extensions/sqlite
       ruby_version: '2.7'
     steps:
-      - browser-tools/install-browser-tools
       - checkout
+      - browser-tools/install-chrome
       - solidusio_extensions/run-tests-solidus-older
       - solidusio_extensions/store-test-results
 
   lint-code:
-    executor: solidusio_extensions/sqlite-memory
+    executor: solidusio_extensions/sqlite
     steps:
-      - browser-tools/install-browser-tools
       - solidusio_extensions/lint-code
 
 workflows:

--- a/Gemfile
+++ b/Gemfile
@@ -25,12 +25,12 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3')
   # the 'async' gem that relies on the latest ruby, since RubyGems doesn't
   # resolve gems based on the required ruby version.
   gem 'async', '< 3', require: false
-
-  # 'net/smtp' is required by 'mail', see:
-  # - https://github.com/ruby/net-protocol/issues/10
-  # - https://stackoverflow.com/a/72474475
-  gem 'net-smtp', require: false
 end
+
+# 'net/smtp' is required by 'mail', see:
+# - https://github.com/ruby/net-protocol/issues/10
+# - https://stackoverflow.com/a/72474475
+gem 'net-smtp', require: false
 
 gemspec
 

--- a/bin/rails
+++ b/bin/rails
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-if %w[g generate].include? ARGV.first
+if %w[g generate].include?(ARGV.first) && ARGV[1] !~ /^(solidus:auth:|solidus_auth_devise:)/
   exec "#{__dir__}/rails-engine", *ARGV
 else
   exec "#{__dir__}/rails-sandbox", *ARGV

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -71,6 +71,7 @@ cat <<RUBY >> Gemfile
 gem 'solidus', github: 'solidusio/solidus', branch: '$BRANCH'
 gem 'rails-i18n'
 gem 'solidus_i18n'
+gem 'net-smtp', require: false
 
 gem '$extension_name', path: '..'
 

--- a/db/default/users.rb
+++ b/db/default/users.rb
@@ -1,78 +1,38 @@
 # frozen_string_literal: true
 
-# see last line where we create an admin if there is none, asking for email and password
-def prompt_for_admin_password
-  if ENV['ADMIN_PASSWORD']
-    password = ENV['ADMIN_PASSWORD'].dup
-    puts "Admin Password #{password}"
-  else
-    print "Password [test123]: "
-    password = STDIN.gets.strip
-    password = 'test123' if password.blank?
-  end
+admin_role = Spree::Role.find_or_create_by(name: 'admin')
 
-  password
+if Spree::User.admin.any?
+  puts 'No admin user created.'
+  return
 end
 
-def prompt_for_admin_email
-  if ENV['ADMIN_EMAIL']
-    email = ENV['ADMIN_EMAIL'].dup
-    puts "Admin User #{email}"
-  else
-    print "Email [admin@example.com]: "
-    email = STDIN.gets.strip
-    email = 'admin@example.com' if email.blank?
-  end
+email = ENV['ADMIN_EMAIL'] || 'admin@example.com'
+password = ENV['ADMIN_PASSWORD'] || 'test123'
 
-  email
+puts "Creating admin user with:"
+puts "  - email: #{email}"
+puts "  - password: #{password}"
+puts "(please use the ADMIN_EMAIL and ADMIN_PASSWORD environment variables to control how the default admin user is created)"
+
+if Spree::User.find_by(email: email)
+  warn "WARNING: There is already a user with the email: #{email}, so no account changes were made."
+  return
 end
 
-def create_admin_user
-  if ENV['AUTO_ACCEPT']
-    password = 'test123'
-    email = 'admin@example.com'
-  else
-    puts 'Create the admin user (press enter for defaults).'
-    # name = prompt_for_admin_name unless name
-    email = prompt_for_admin_email
-    password = prompt_for_admin_password
-  end
-  attributes = {
-    password: password,
-    password_confirmation: password,
-    email: email,
-    login: email
-  }
+admin = Spree::User.new(
+  password: password,
+  password_confirmation: password,
+  email: email,
+  login: email,
+)
 
-  load 'spree/user.rb'
-
-  if Spree::User.find_by(email: email)
-    puts "\nWARNING: There is already a user with the email: #{email}, so no account changes were made.  If you wish to create an additional admin user, please run rake spree_auth:admin:create again with a different email.\n\n"
-  else
-    admin = Spree::User.new(attributes)
-    if admin.save
-      role = Spree::Role.find_or_create_by(name: 'admin')
-      admin.spree_roles << role
-      admin.save
-      admin.generate_spree_api_key!
-      puts "Done!"
-    else
-      puts "There were some problems with persisting a new admin user:"
-      admin.errors.full_messages.each do |error|
-        puts error
-      end
-    end
-  end
-end
-
-if Spree::User.admin.empty?
-  create_admin_user
+if admin.save
+  admin.spree_roles << admin_role
+  admin.save
+  admin.generate_spree_api_key!
 else
-  puts 'Admin user has already been created.'
-  puts 'Would you like to create a new admin user? (yes/no)'
-  if ["yes", "y"].include? STDIN.gets.strip.downcase
-    create_admin_user
-  else
-    puts 'No admin user created.'
-  end
+  warn "There were some problems while creating the admin user:"
+  warn(admin.errors.full_messages.map { |m| "- #{m}" })
+  warn "(attributes: #{admin.attributes.inspect})"
 end

--- a/lib/generators/solidus_auth_devise/install/install_generator.rb
+++ b/lib/generators/solidus_auth_devise/install/install_generator.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
 require_relative '../../solidus/auth/install/install_generator'
+
 module SolidusAuthDevise
   module Generators
-    InstallGenerator = ::Solidus::Auth::Generators::InstallGenerator
+    class InstallGenerator < Rails::Generators::Base
+      # Copy over any class option from the legacy install generator
+      Solidus::Auth::Generators::InstallGenerator.class_options.each do |name, option|
+        class_options[name] ||= option.dup
+      end
+
+      def forward_to_spree_auth_install
+        generate 'solidus:auth:install', *ARGV
+      end
+    end
   end
 end

--- a/lib/solidus_auth_devise/engine.rb
+++ b/lib/solidus_auth_devise/engine.rb
@@ -1,7 +1,3 @@
 # frozen_string_literal: true
 
 require 'spree/auth/engine'
-
-module SolidusAuthDevise
-  Engine = ::Spree::Auth::Engine
-end

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -95,3 +95,5 @@ module Spree
     end
   end
 end
+
+SolidusAuthDevise::Engine = Spree::Auth::Engine


### PR DESCRIPTION
This generator is here for anyone trying to run th standard `bin/rails g solidus_auth_devise:install`. Turns out that assigning to another constant is not enough and we need to proxy it more explicitly.