### PR TITLE
Remove unused authentication_token column

### DIFF
--- a/db/migrate/20101026184950_rename_columns_for_devise.rb
+++ b/db/migrate/20101026184950_rename_columns_for_devise.rb
@@ -14,14 +14,12 @@ class RenameColumnsForDevise < SolidusSupport::Migration[4.2]
     rename_column :spree_users, :last_login_at, :last_sign_in_at
     rename_column :spree_users, :current_login_ip, :current_sign_in_ip
     rename_column :spree_users, :last_login_ip, :last_sign_in_ip
-    add_column :spree_users, :authentication_token, :string
     add_column :spree_users, :unlock_token, :string
     add_column :spree_users, :locked_at, :datetime
     remove_column :spree_users, :openid_identifier
   end
 
   def down
-    remove_column :spree_users, :authentication_token
     remove_column :spree_users, :locked_at
     remove_column :spree_users, :unlock_token
     rename_column :spree_users, :last_sign_in_ip, :last_login_ip


### PR DESCRIPTION
## Summary

This column dates back to 2013, when token authentication was removed from Devise. We should not keep it.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] ~I have added automated tests to cover my changes.~
- [ ] ~I have attached screenshots to demo visual changes.~
- [ ] ~I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- [ ] ~I have updated the README to account for my changes.~
