### PR TITLE
Remove Slack notifications for CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,16 +10,6 @@ orbs:
   # or goes EOL.
   solidusio_extensions: solidusio/extensions@volatile
 
-  slack: circleci/slack@4.9.3
-
-commands:
-  notify:
-      steps:
-        - slack/notify:
-            event: fail
-            template: basic_fail_1
-            branch_pattern: master
-
 jobs:
   run-specs-with-postgres:
     executor:
@@ -30,7 +20,6 @@ jobs:
       - browser-tools/install-chrome
       - solidusio_extensions/run-tests-solidus-master
       - solidusio_extensions/store-test-results
-      - notify
 
   run-specs-with-mysql:
     executor:
@@ -41,7 +30,6 @@ jobs:
       - browser-tools/install-chrome
       - solidusio_extensions/run-tests-solidus-current
       - solidusio_extensions/store-test-results
-      - notify
 
   run-specs-with-sqlite:
     executor:
@@ -52,25 +40,19 @@ jobs:
       - browser-tools/install-chrome
       - solidusio_extensions/run-tests-solidus-older
       - solidusio_extensions/store-test-results
-      - notify
 
   lint-code:
     executor: solidusio_extensions/sqlite
     steps:
       - solidusio_extensions/lint-code
-      - notify
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres:
-          context: slack-secrets
-      - run-specs-with-mysql:
-          context: slack-secrets
-      - run-specs-with-sqlite:
-          context: slack-secrets
-      - lint-code:
-          context: slack-secrets
+      - run-specs-with-postgres
+      - run-specs-with-mysql
+      - run-specs-with-sqlite
+      - lint-code
 
   "Weekly run specs against master":
     triggers:
@@ -81,9 +63,6 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres:
-          context: slack-secrets
-      - run-specs-with-mysql:
-          context: slack-secrets
-      - run-specs-with-sqlite:
-          context: slack-secrets
+      - run-specs-with-postgres
+      - run-specs-with-mysql
+      - run-specs-with-sqlite


### PR DESCRIPTION
## Summary

We were storing the Slack secrets on a [CircleCI context](https://circleci.com/docs/contexts/). Although we were also [passing them to forks](https://circleci.com/docs/oss/#pass-secrets-to-builds-from-forked-pull-requests), it resulted on unauthorized builds for external contributions.

We could work around the issue in two ways:

- Having the secrets outside of any context, but that would compromise the security of the associated Slack channel for:
  - Send messages as @<!---->CircleCI notifications
  - Send messages to channels @<!---->CircleCI notifications isn't a member of
  - Upload, edit, and delete files as CircleCI notifications
- Using CircleCI [logic statements](https://circleci.com/docs/configuration-reference/#logic-statements) to conditionally run jobs when `CIRCLECI_USERNAME` or `CIRCLE_PR_USERNAME` [env vars](https://circleci.com/docs/variables/) are in a list of allowed users. However, that would be something difficult to maintain, and there's no other way to check the user's role.

Given that we don't find those trade-offs to be acceptable, we remove the integration for now.

Closes #4902

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.