### PR TITLE
Fix CI on Solidus v3.1 by explicitly fetching solidus_frontend from GH

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,13 @@ gem 'solidus', github: 'solidusio/solidus', branch: branch
 gem 'solidus_backend', github: 'solidusio/solidus', branch: branch
 
 # The solidus_frontend gem has been pulled out since v3.2
-gem 'solidus_frontend', github: 'solidusio/solidus_frontend' if branch == 'master'
-gem 'solidus_frontend' if branch >= 'v3.2' # rubocop:disable Bundler/DuplicatedGem
+if branch >= 'v3.2'
+  gem 'solidus_frontend'
+elsif branch == 'master'
+  gem 'solidus_frontend', github: 'solidusio/solidus_frontend'
+else
+  gem 'solidus_frontend', github: 'solidusio/solidus', branch: branch
+end
 
 case ENV.fetch('DB', nil)
 when 'mysql'


### PR DESCRIPTION
## Summary

This is the same fix that was used in 9f1f60bf5a4032c3c94cc906b074245f4ab01b97. Otherwise, bundler will try to fetch the gem from RubyGems and complain because not finding `v3.1.10.dev` version.

Closes #239

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
