### PR TITLE
Update CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,47 +11,47 @@ orbs:
   solidusio_extensions: solidusio/extensions@volatile
 
 jobs:
-  run-specs-with-postgres:
+  run-specs:
+    parameters:
+      solidus:
+        type: string
+        default: master
+      db:
+        type: string
+        default: "postgres"
+      ruby:
+        type: string
+        default: "3.2"
     executor:
-      name: solidusio_extensions/postgres
-      ruby_version: '3.1'
+      name: solidusio_extensions/<< parameters.db >>
+      ruby_version: << parameters.ruby >>
     steps:
       - checkout
       - browser-tools/install-chrome
-      - solidusio_extensions/run-tests-solidus-master
-      - solidusio_extensions/store-test-results
-
-  run-specs-with-mysql:
-    executor:
-      name: solidusio_extensions/mysql
-      ruby_version: '3.0'
-    steps:
-      - checkout
-      - browser-tools/install-chrome
-      - solidusio_extensions/run-tests-solidus-current
-      - solidusio_extensions/store-test-results
-
-  run-specs-with-sqlite:
-    executor:
-      name: solidusio_extensions/sqlite
-      ruby_version: '2.7'
-    steps:
-      - checkout
-      - browser-tools/install-chrome
-      - solidusio_extensions/run-tests-solidus-older
-      - solidusio_extensions/store-test-results
+      - solidusio_extensions/run-tests-solidus-<< parameters.solidus >>
 
   lint-code:
-    executor: solidusio_extensions/sqlite
+    executor:
+      name: solidusio_extensions/sqlite
+      ruby_version: "3.0"
     steps:
       - solidusio_extensions/lint-code
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
-      - run-specs-with-sqlite
+      - run-specs:
+          name: &name "run-specs-solidus-<< matrix.solidus >>-ruby-<< matrix.ruby >>-db-<< matrix.db >>"
+          matrix:
+            parameters: { solidus: ["master"], ruby: ["3.2"], db: ["postgres"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["current"], ruby: ["3.1"], db: ["mysql"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["older"], ruby: ["3.0"], db: ["sqlite"] }
       - lint-code
 
   "Weekly run specs against master":
@@ -63,6 +63,11 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
-      - run-specs-with-sqlite
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["master"], ruby: ["3.2"], db: ["postgres"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["current"], ruby: ["3.1"], db: ["mysql"] }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ require:
 
 AllCops:
   NewCops: disable
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/spec/support/spree.rb
+++ b/spec/support/spree.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/authorization_helpers'


### PR DESCRIPTION
## Summary

Run different Solidus versions on different jobs for better error handling.

We're now explicitly providing the ruby version to the executor while using a matrix configuration for better extensibility.

We're now running the linter on Ruby v3.0, as that's the minimal requirement for Solidus master. As a consequence, we disable the cop for following the gemspec version.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
