### PR TITLE
Ensure the admin sign in root path fallback is '/admin'

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -105,7 +105,7 @@ RSpec/BeforeAfterAll:
 
 # Offense count: 5
 # This cop supports safe autocorrection (--autocorrect).
-RSpec/Capybara/CurrentPathExpectation:
+Capybara/CurrentPathExpectation:
   Exclude:
     - 'spec/features/admin/sign_in_spec.rb'
     - 'spec/features/sign_in_spec.rb'
@@ -221,7 +221,6 @@ RSpec/InstanceVariable:
     - 'spec/controllers/spree/admin/user_passwords_controller_spec.rb'
     - 'spec/controllers/spree/user_passwords_controller_spec.rb'
     - 'spec/controllers/spree/user_registrations_controller_spec.rb'
-    - 'spec/controllers/spree/user_sessions_controller_spec.rb'
     - 'spec/features/admin/sign_in_spec.rb'
     - 'spec/features/checkout_spec.rb'
     - 'spec/features/sign_in_spec.rb'

--- a/lib/controllers/backend/spree/admin/user_sessions_controller.rb
+++ b/lib/controllers/backend/spree/admin/user_sessions_controller.rb
@@ -35,6 +35,10 @@ class Spree::Admin::UserSessionsController < Devise::SessionsController
 
   private
 
+  def signed_in_root_path(_resource)
+    spree.admin_path
+  end
+
   # NOTE: as soon as this gem stops supporting Solidus 3.1 if-else should be removed and left only include
   if defined?(::Spree::Admin::SetsUserLanguageLocaleKey)
     include ::Spree::Admin::SetsUserLanguageLocaleKey

--- a/spec/controllers/spree/admin/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/admin/user_sessions_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Spree::Admin::UserSessionsController, type: :controller do
+  let(:user) { create(:user, password: 'secret') }
+
+  before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] }
+
+  it "redirects to the admin root after signing in with no stored location" do
+    get :new
+
+    post(:create,
+      params: {
+        spree_user: {
+          email: user.email,
+          password: 'secret'
+        },
+      }
+    )
+
+    expect(response).to redirect_to spree.admin_path
+  end
+end

--- a/spec/controllers/spree/admin/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/admin/user_sessions_controller_spec.rb
@@ -3,19 +3,17 @@
 RSpec.describe Spree::Admin::UserSessionsController, type: :controller do
   let(:user) { create(:user, password: 'secret') }
 
-  before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] }
+  before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] } # rubocop:disable RSpec/InstanceVariable
 
   it "redirects to the admin root after signing in with no stored location" do
     get :new
 
-    post(:create,
-      params: {
-        spree_user: {
-          email: user.email,
-          password: 'secret'
-        },
-      }
-    )
+    post(:create, params: {
+      spree_user: {
+        email: user.email,
+        password: 'secret'
+      },
+    })
 
     expect(response).to redirect_to spree.admin_path
   end

--- a/spec/controllers/spree/user_sessions_controller_spec.rb
+++ b/spec/controllers/spree/user_sessions_controller_spec.rb
@@ -3,22 +3,20 @@
 RSpec.describe Spree::UserSessionsController, type: :controller do
   let(:user) { create(:user) }
 
-  before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] }
+  before { @request.env['devise.mapping'] = Devise.mappings[:spree_user] } # rubocop:disable RSpec/InstanceVariable
 
   context "#create" do
     let(:format) { :html }
     let(:password) { 'secret' }
 
     subject do
-      post(:create,
-        params: {
-          spree_user: {
-            email: user.email,
-            password: password
-          },
-          format: format
-        }
-      )
+      post(:create, params: {
+        spree_user: {
+          email: user.email,
+          password: password
+        },
+        format: format
+      })
     end
 
     context "when using correct login information" do

--- a/spec/features/admin/sign_in_spec.rb
+++ b/spec/features/admin/sign_in_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Admin - Sign In', type: :feature do
   background do
-    @user = create(:user, email: 'email@person.com')
+    @user = create(:admin_user, email: 'email@person.com')
     visit spree.admin_login_path
   end
 
@@ -19,7 +19,7 @@ RSpec.feature 'Admin - Sign In', type: :feature do
     expect(page).to have_text 'Logged in successfully'
     expect(page).not_to have_text 'Login'
     expect(page).to have_text 'Logout'
-    expect(current_path).to eq '/'
+    expect(current_path).to eq '/admin/orders'
   end
 
   scenario 'shows validation erros' do


### PR DESCRIPTION
## Summary

Previously relied on solidus_frontend defining `spree.root_path`, and used it redirecting admin users to the store home page.


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
