### PR TITLE
Fix failing spec for admin logout

### DIFF
--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -4,7 +4,7 @@
 Warden::Manager.after_set_user except: :fetch do |user, auth, _opts|
   if auth.cookies.signed[:guest_token].present?
     if user.is_a?(Spree::User)
-      Spree::Order.incomplete.where(guest_token: auth.cookies.signed[:guest_token], user_id: nil).each do |order|
+      Spree::Order.incomplete.where(guest_token: auth.cookies.signed[:guest_token], user_id: nil).find_each do |order|
         order.associate_user!(user)
       end
     end

--- a/spec/features/admin/sign_out_spec.rb
+++ b/spec/features/admin/sign_out_spec.rb
@@ -15,9 +15,28 @@ RSpec.feature 'Admin - Sign Out', type: :feature, js: true do
   end
 
   scenario 'allows a signed in user to logout' do
-    click_link 'Logout'
+    click_logout_link
     visit spree.admin_login_path
     expect(page).to have_text 'Login'
     expect(page).not_to have_text 'Logout'
+  end
+
+  def click_logout_link
+    new_version? ? logout_new_version : logout_old_version
+  end
+
+  def new_version?
+    Gem::Requirement.new('>= 4.2').satisfied_by?(Spree.solidus_gem_version)
+  end
+
+  def logout_new_version
+    find('details div', text: user.email, wait: 10).click
+    within('details') do
+      click_link 'Logout'
+    end
+  end
+
+  def logout_old_version
+    click_link 'Logout'
   end
 end


### PR DESCRIPTION
## Summary

After updating the Solidus navigation bar, the feature spec for admin logout started failing.
The `Logout` link is now contained within a `<details>` tag, which needs to be clicked to reveal the logout option.

<img width="1840" alt="Screenshot 2023-10-04 at 16 59 57" src="https://github.com/solidusio/solidus_auth_devise/assets/19948291/94638409-6e62-4460-a1ae-1221df195776">


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
