### PR TITLE
[Rails 7.1] Add empty :new action to Spree::UsersController

### DIFF
--- a/lib/controllers/frontend/spree/users_controller.rb
+++ b/lib/controllers/frontend/spree/users_controller.rb
@@ -4,6 +4,8 @@ class Spree::UsersController < Spree::StoreController
   skip_before_action :set_current_order, only: :show, raise: false
   prepend_before_action :authorize_actions, only: :new
 
+  def new; end
+
   def show
     load_object
     @orders = @user.orders.complete.order('completed_at desc')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Spree::User, type: :model do
     let(:user) { create(:user) }
 
     context 'with same email address as previously deleted account' do
-      it 'will allow users to register later' do
+      it 'allows users to register later' do
         user1 = build(:user)
         user1.save
 


### PR DESCRIPTION


## Summary

Without this, specs fail with
```
AbstractController::ActionNotFound:
        The new action could not be found for the :authorize_actions
        callback on Spree::UsersController, but it is listed in the controller's
        :only option.
```

I guess this is because the views are not in the standard place, thus impeding Rails' ability to dynamically generate empty actions if matching views are present. Anyways: This is good, because it's more explicit.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
