### PR TITLE
Set User Class on Boot

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,6 @@ ENV['SKIP_SOLIDUS_BOLT'] = 'true'
 require 'bundler/gem_tasks'
 
 require 'solidus_dev_support/rake_tasks'
-SolidusDevSupport::RakeTasks.install
+SolidusDevSupport::RakeTasks.install(user_class: "Spree::User")
 
 task default: 'extension:specs'

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -13,14 +13,12 @@ module Spree
       isolate_namespace Spree
       engine_name 'solidus_auth'
 
+      Spree.user_class = "Spree::User"
+
       initializer "spree.auth.environment", before: :load_config_initializers do |_app|
         require 'spree/auth_configuration'
 
         Spree::Auth::Config = Spree::AuthConfiguration.new
-      end
-
-      initializer "solidus_auth_devise.set_user_class", after: :load_config_initializers do
-        Spree.user_class = "Spree::User"
       end
 
       config.to_prepare do

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'solidus_backend'
   spec.add_development_dependency 'solidus_frontend'
-  spec.add_development_dependency 'solidus_dev_support', '~> 2.5'
+  spec.add_development_dependency 'solidus_dev_support', '~> 2.10'
   spec.add_development_dependency 'rails-controller-testing'
 end


### PR DESCRIPTION
For most of the Rails boot process, an app running solidus_auth_devise believes that its user class is whatever is configured in the config/spree.rb initializer. However, if `solidus_auth_devise` is installed, that is changed after most things have been configured.

It need not be this way: If we want this gem to set a default, we should set it really early on, not in one of the last initializers to run (they also run alphabetically, so `solidus_auth_devise` initializers run quite late).

Specifically, for using the new patch mechanism in https://github.com/friendlycart/flickwerk, `Spree.user_class` needs to be correct by the time the Rails finisher runs (when the `setup_main_autoloader` initializer runs).



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
