### PR TITLE
CI: Lint with Ruby 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
   lint-code:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: "3.0"
+      ruby_version: "3.1"
     steps:
       - solidusio_extensions/lint-code
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3')


### PR DESCRIPTION
We install latest Solidus during linting code
and this requires at least Ruby 3.1.

Also we need to pin sqlite3 gem to v1.4 in order to work with Rails 7.0