### PR TITLE
Do not reload routes before application startup

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -143,4 +143,6 @@ Devise.setup do |config|
   config.reset_password_within = 6.hours
 
   config.case_insensitive_keys = [:email]
+
+  config.reload_routes = false
 end


### PR DESCRIPTION
This devise.rb initializer is run for most stores, and by setting `reload_routes` to `false`, we can avoid Devise reloading the routes in an initializer. Rails will do this just fine, but not in the initializer chain.
