### PR TITLE
Use new unauthorized redirect handler class endpoints

### DIFF
--- a/app/models/spree/auth/unauthorized_admin_access_handler.rb
+++ b/app/models/spree/auth/unauthorized_admin_access_handler.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Spree
+  module Auth
+    # This service object is responsible for handling unauthorized redirects
+    class UnauthorizedAdminAccessHandler
+      # @param controller [ApplicationController] an instance of ApplicationController
+      #  or its subclasses.
+      def initialize(controller)
+        @controller = controller
+      end
+
+      # This method is responsible for handling unauthorized redirects
+      def call
+        if spree_current_user
+          flash[:error] = I18n.t('spree.authorization_failure')
+
+          redirect_to(spree.admin_unauthorized_path)
+        else
+          store_location
+
+          redirect_to(spree.admin_login_path)
+        end
+      end
+
+      private
+
+      attr_reader :controller
+
+      delegate :flash, :redirect_to, :spree_current_user, :store_location, :spree, to: :controller
+    end
+  end
+end

--- a/app/models/spree/auth/unauthorized_customer_access_handler.rb
+++ b/app/models/spree/auth/unauthorized_customer_access_handler.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Spree
+  module Auth
+    # This service object is responsible for handling unauthorized redirects
+    class UnauthorizedCustomerAccessHandler
+      # @param controller [ApplicationController] an instance of ApplicationController
+      #  or its subclasses.
+      def initialize(controller)
+        @controller = controller
+      end
+
+      # This method is responsible for handling unauthorized redirects
+      def call
+        if spree_current_user
+          flash[:error] = I18n.t('spree.authorization_failure')
+
+          redirect_back(fallback_location: spree.unauthorized_path)
+        else
+          store_location
+
+          redirect_back(fallback_location: spree.login_path)
+        end
+      end
+
+      private
+
+      attr_reader :controller
+
+      delegate :flash, :redirect_back, :spree_current_user, :store_location, :spree, to: :controller
+    end
+  end
+end

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -26,42 +26,16 @@ module Spree
         Spree::Auth::Engine.prepare_frontend if SolidusSupport.frontend_available?
       end
 
-      def self.redirect_back_on_unauthorized?
-        return false unless Spree::Config.respond_to?(:redirect_back_on_unauthorized)
-
-        if Spree::Config.redirect_back_on_unauthorized
-          true
-        else
-          Spree::Deprecation.warn <<-WARN.strip_heredoc, caller
-            Having Spree::Config.redirect_back_on_unauthorized set
-            to `false` is deprecated and will not be supported in Solidus 3.0.
-            Please change this configuration to `true` and be sure that your
-            application does not break trying to redirect back when there is
-            an unauthorized access.
-          WARN
-
-          false
-        end
-      end
-
       def self.prepare_backend
         Spree::Admin::BaseController.unauthorized_redirect = -> do
           if spree_current_user
             flash[:error] = I18n.t("spree.authorization_failure")
 
-            if Spree::Auth::Engine.redirect_back_on_unauthorized?
-              redirect_back(fallback_location: spree.admin_unauthorized_path)
-            else
-              redirect_to spree.admin_unauthorized_path
-            end
+            redirect_to(spree.admin_unauthorized_path)
           else
             store_location
 
-            if Spree::Auth::Engine.redirect_back_on_unauthorized?
-              redirect_back(fallback_location: spree.admin_login_path)
-            else
-              redirect_to spree.admin_login_path
-            end
+            redirect_to(spree.admin_login_path)
           end
         end
       end
@@ -71,19 +45,11 @@ module Spree
           if spree_current_user
             flash[:error] = I18n.t("spree.authorization_failure")
 
-            if Spree::Auth::Engine.redirect_back_on_unauthorized?
-              redirect_back(fallback_location: spree.unauthorized_path)
-            else
-              redirect_to spree.unauthorized_path
-            end
+            redirect_back(fallback_location: spree.unauthorized_path)
           else
             store_location
 
-            if Spree::Auth::Engine.redirect_back_on_unauthorized?
-              redirect_back(fallback_location: spree.login_path)
-            else
-              redirect_to spree.login_path
-            end
+            redirect_back(fallback_location: spree.login_path)
           end
         end
       end

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -21,9 +21,20 @@ module Spree
         Spree::Auth::Config = Spree::AuthConfiguration.new
       end
 
+      if Spree::Config.respond_to?(:unauthorized_redirect_handler_class)
+        Spree::Config.unauthorized_redirect_handler_class = "Spree::Auth::UnauthorizedCustomerAccessHandler"
+        if SolidusSupport.backend_available?
+          Spree::Backend::Config.unauthorized_redirect_handler_class = "Spree::Auth::UnauthorizedAdminAccessHandler"
+        end
+      else
+        config.to_prepare do
+          Spree::Auth::Engine.prepare_backend if SolidusSupport.backend_available?
+          Spree::Auth::Engine.prepare_frontend if SolidusSupport.frontend_available?
+        end
+      end
+
       config.to_prepare do
-        Spree::Auth::Engine.prepare_backend if SolidusSupport.backend_available?
-        Spree::Auth::Engine.prepare_frontend if SolidusSupport.frontend_available?
+        ApplicationController.include Spree::AuthenticationHelpers
       end
 
       def self.prepare_backend

--- a/lib/spree/auth/engine.rb
+++ b/lib/spree/auth/engine.rb
@@ -28,29 +28,13 @@ module Spree
 
       def self.prepare_backend
         Spree::Admin::BaseController.unauthorized_redirect = -> do
-          if spree_current_user
-            flash[:error] = I18n.t("spree.authorization_failure")
-
-            redirect_to(spree.admin_unauthorized_path)
-          else
-            store_location
-
-            redirect_to(spree.admin_login_path)
-          end
+          Spree::Auth::UnauthorizedAdminAccessHandler.new(self).call
         end
       end
 
       def self.prepare_frontend
         Spree::BaseController.unauthorized_redirect = -> do
-          if spree_current_user
-            flash[:error] = I18n.t("spree.authorization_failure")
-
-            redirect_back(fallback_location: spree.unauthorized_path)
-          else
-            store_location
-
-            redirect_back(fallback_location: spree.login_path)
-          end
+          Spree::Auth::UnauthorizedCustomerAccessHandler.new(self).call
         end
       end
     end

--- a/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/spec/controllers/spree/admin/base_controller_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe Spree::Admin::BaseController, type: :controller do
       end
     end
 
-    before do
-      stub_spree_preferences(Spree::Config, redirect_back_on_unauthorized: true)
-    end
-
     context "when user is logged in" do
       before { sign_in(create(:user)) }
 
@@ -23,15 +19,6 @@ RSpec.describe Spree::Admin::BaseController, type: :controller do
           expect(response).to redirect_to(spree.admin_unauthorized_path)
         end
       end
-
-      context "when http_referrer is present" do
-        before { request.env["HTTP_REFERER"] = "/redirect" }
-
-        it "redirects back" do
-          get :index
-          expect(response).to redirect_to("/redirect")
-        end
-      end
     end
 
     context "when user is not logged in" do
@@ -39,15 +26,6 @@ RSpec.describe Spree::Admin::BaseController, type: :controller do
         it "redirects to login path" do
           get :index
           expect(response).to redirect_to(spree.admin_login_path)
-        end
-      end
-
-      context "when http_referrer is present" do
-        before { request.env["HTTP_REFERER"] = "/redirect" }
-
-        it "redirects back" do
-          get :index
-          expect(response).to redirect_to("/redirect")
         end
       end
     end

--- a/spec/controllers/spree/base_controller_spec.rb
+++ b/spec/controllers/spree/base_controller_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe Spree::BaseController, type: :controller do
       end
     end
 
-    before do
-      stub_spree_preferences(Spree::Config, redirect_back_on_unauthorized: true)
-    end
-
     context "when user is logged in" do
       before { sign_in(create(:user)) }
 


### PR DESCRIPTION
## Summary

This PR drops support for the old configuration option `Spree::Config.redirect_back_on_unauthorized` and extracts the redirect handling into classes, which can then be fed into the new extension points from https://github.com/solidusio/solidus/pull/6051.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
