### PR TITLE
Allow Ruby 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,5 @@ permissions:
 jobs:
   Test:
     uses: solidusio/test-solidus-extension/.github/workflows/test.yml@v1
+    with:
+      ruby_versions: "['3.4', '4.0']"

--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,8 @@ send(:eval_gemfile, "Gemfile-local") if File.exist? "Gemfile-local"
 
 # Pin state_machines
 gem "state_machines", "= 0.6.0"
+
+if RUBY_VERSION >= "4.0"
+  # Necessary for github_changelog_generator
+  gem "benchmark", "~> 0.5.0"
+end

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/solidusio/solidus_auth_devise"
   spec.metadata["changelog_uri"] = "https://github.com/solidusio/solidus_auth_devise/releases"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5", "< 4")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5", "< 5")
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
## Summary

Ruby 4.0 has just been released and we should start testing it.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
