### PR TITLE
Relax Devise version constraint

### DIFF
--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "deface", "~> 1.0"
-  spec.add_dependency "devise", "~> 4.1"
+  spec.add_dependency "devise", ">= 4.1"
   spec.add_dependency "devise-encryptable", "0.2.0"
   spec.add_dependency "solidus_core", [">= 3", "< 5"]
   spec.add_dependency "solidus_support", "~> 0.11"


### PR DESCRIPTION
Version 5.0 might actually be coming and the RC contains Rails 8 (lazy loaded routes) fixes.
