### PR TITLE
Upgrade to Devise 5.0.3

### DIFF
--- a/lib/solidus_auth_devise/version.rb
+++ b/lib/solidus_auth_devise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusAuthDevise
-  VERSION = "2.5.9"
+  VERSION = "2.6.0"
 end

--- a/solidus_auth_devise.gemspec
+++ b/solidus_auth_devise.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "deface", "~> 1.0"
-  spec.add_dependency "devise", ">= 4.1"
+  spec.add_dependency "devise", ">= 5.0.3"
   spec.add_dependency "devise-encryptable", "0.2.0"
   spec.add_dependency "solidus_core", [">= 3", "< 5"]
   spec.add_dependency "solidus_support", "~> 0.11"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Spree::User, type: :model do
     let(:user) { create(:user) }
 
     it "generates the reset password token" do
-      expect(Spree::UserMailer).to receive(:reset_password_instructions).with(user, anything, {}).and_return(double(deliver: true))
+      expect(Spree::UserMailer).to receive(:reset_password_instructions).with(user, anything, {}).and_return(double(deliver_now: true))
       expect { user.send_reset_password_instructions }.to change(user, :reset_password_token).to be_present
     end
 


### PR DESCRIPTION
## Summary
Updates and requires at least Devise to 5.0.3. Lesser versions have a security vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2026-32700

Notably, with this jump to Devise 5.0.3...
Secret key resolution changed: Devise now uses application.secret_key_base directly instead of searching through credentials/secrets. Existing tokens (recoverable, lockable, confirmable) could be invalidated if the effective key changes.

Also, some deprecations are removed:
`sign_in(resource, :bypass)` — use bypass_sign_in instead
`devise_error_messages! `helper — use render "devise/shared/error_messages" partial
`sign_in(resource, scope: :admin)` keyword arg instead of positional
`Devise::TestHelpers` — use Devise::Test::ControllerHelpers

Of course, there is the vulnerability fix as well.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
