### PR TITLE
Fix Devise 5 compatibility: replace deprecated positional scope in sign_in

### DIFF
--- a/lib/controllers/frontend/spree/user_registrations_controller.rb
+++ b/lib/controllers/frontend/spree/user_registrations_controller.rb
@@ -15,7 +15,7 @@ class Spree::UserRegistrationsController < Devise::RegistrationsController
     build_resource(spree_user_params)
     if resource.save
       set_flash_message(:notice, :signed_up)
-      sign_in(:spree_user, resource)
+      sign_in(resource)
       session[:spree_user_signup] = true
       respond_with resource, location: after_sign_up_path_for(resource)
     else

--- a/lib/solidus_auth_devise/version.rb
+++ b/lib/solidus_auth_devise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusAuthDevise
-  VERSION = "2.6.0"
+  VERSION = "2.6.1"
 end


### PR DESCRIPTION
## Summary

Fixes Devise 5.x runtime compatibility by replacing the deprecated positional scope argument in `sign_in` and bumping the gem version to 2.6.1.

### What changed

1. **`sign_in(:spree_user, resource)` → `sign_in(resource)`** in `UserRegistrationsController#create`

   Devise 5 removed the deprecated `sign_in(scope, resource)` form. The scope is inferred automatically from the resource's class mapping (`Spree::User` → `:spree_user`), so the explicit scope argument is unnecessary and causes a runtime error with Devise >= 5.0.

2. **Version bump to 2.6.1**

### Why this matters

The gemspec already allows Devise 5.x (`>= 4.1`), but the code-level incompatibility causes a `ArgumentError` during user registration when running with Devise 5. This is the only Devise 5 incompatibility in the codebase — all other deprecated patterns (`sign_in(:bypass)`, `devise_error_messages!`, `Devise::TestHelpers`, `deliver`) were already updated in previous releases.

### Context

[CVE-2026-32700](https://nvd.nist.gov/vuln/detail/CVE-2026-32700) affects Devise < 5.0.3 (email confirmation race condition). Downstream Solidus apps cannot upgrade to the patched Devise version without this fix. See also #271.

### Backwards compatible

`sign_in(resource)` works identically on Devise 4.x and 5.x — Devise has inferred scopes from resource class mappings since 4.0. No behavior change for existing installations.

## Checklist

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
- [x] I have added automated tests to cover my changes.