### PR TITLE
feat(User): Add timezone

### DIFF
--- a/db/migrate/20260422183113_add_timezone_to_spree_users.rb
+++ b/db/migrate/20260422183113_add_timezone_to_spree_users.rb
@@ -1,0 +1,6 @@
+class AddTimezoneToSpreeUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_users, :timezone, :string, if_not_exists: true,
+      comment: "User's timezone, e.g., 'Eastern Time (US & Canada)'"
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Spree::User, type: :model do
     expect(create(:user).admin?).to be false
   end
 
+  describe "#timezone" do
+    subject(:user) { create(:user) }
+    it { expect(user).to respond_to(:timezone) }
+  end
+
   context "recoverable" do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
## Summary

Can be used to store the preferred timezone. Is used in Solidus 4.8 if present. See https://github.com/solidusio/solidus/pull/6437

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
